### PR TITLE
Update firefox to 47.0 in gemini config

### DIFF
--- a/packages/ring-ui-gemini/.gemini.conf.js
+++ b/packages/ring-ui-gemini/.gemini.conf.js
@@ -39,7 +39,7 @@ module.exports = {
       windowSize,
       desiredCapabilities: {
         browserName: 'firefox',
-        version: '42.0',
+        version: '47.0',
         platform: WIN10
       }
     },


### PR DESCRIPTION
It turned out that Sauce Labs provides Firefox 47.0 (Windows 10). Fortunately, there are no image diffs between 42 and 47.

Gemini does not support Firefox 48+ because `gemini` uses `wd` (https://github.com/admc/wd) package which does not support Selenium 3.0 yet. No estimates from gemini side.