### PR TITLE
storybook: fix auth dialog dissapearing after swithcing to another section

### DIFF
--- a/components/auth-dialog-service/auth-dialog-service.examples.js
+++ b/components/auth-dialog-service/auth-dialog-service.examples.js
@@ -31,10 +31,16 @@ storiesOf('Services|Auth Dialog Service', module).
         });
       }
 
+      componentWillUnmount() {
+        if (this.hideAuthDialog) {
+          this.hideAuthDialog();
+        }
+      }
+
       showAuthDialog = () => {
         const {serviceDetails} = this.state;
 
-        showAuthDialog({
+        this.hideAuthDialog = showAuthDialog({
           serviceDetails,
           errorMessage: 'Error message',
           onConfirm: action('onConfirm'),


### PR DESCRIPTION
Currently if you select auth service in storybook and then switch to another section, the auth dialog will remain.
Fixed this by calling remove callback in unmount hook.