### PR TITLE
Loader: add `deterministic` prop to be able to derandomize it

### DIFF
--- a/components/loader/loader.js
+++ b/components/loader/loader.js
@@ -16,7 +16,8 @@ export default class Loader extends PureComponent {
     colors: PropTypes.array,
     message: PropTypes.string,
     'data-test': PropTypes.string,
-    stop: PropTypes.bool
+    stop: PropTypes.bool,
+    deterministic: PropTypes.bool
   };
 
   componentDidUpdate(prevProps) {
@@ -40,7 +41,16 @@ export default class Loader extends PureComponent {
   };
 
   render() {
-    const {message, size, colors, 'data-test': dataTest, stop, ...restProps} = this.props;
+    const {
+      message,
+      size,
+      colors,
+      'data-test': dataTest,
+      stop,
+      deterministic,
+      ...restProps
+    } = this.props;
+
     return (
       <div
         data-test={dataTests('ring-loader', dataTest)}

--- a/components/loader/loader__core.js
+++ b/components/loader/loader__core.js
@@ -34,10 +34,17 @@ class Particle {
   }
 }
 
+const DETERMINISTIC_VALUE = 0.5;
+
+function deterministic() {
+  return DETERMINISTIC_VALUE;
+}
+
 export default class LoaderCore {
   static defaultProps = {
     size: 64,
     stop: false,
+    deterministic: false,
     colors: [
       {r: 215, g: 60, b: 234}, //#D73CEA
       {r: 145, g: 53, b: 224}, //#9135E0
@@ -127,7 +134,8 @@ export default class LoaderCore {
   }
 
   handleLimits(coord, radius, speed, limit) {
-    const randomizedSpeedChange = Math.random(this.baseSpeed) - this.baseSpeed / 2;
+    const randomFunc = this.deterministic ? deterministic : Math.random;
+    const randomizedSpeedChange = randomFunc(this.baseSpeed) - this.baseSpeed / 2;
 
     if (coord + (radius * 2) + this.baseSpeed >= limit) {
       return -(this.baseSpeed + randomizedSpeedChange);


### PR DESCRIPTION
It's often an issue to test components that use random values. To simplify this, I've added the `deterministic` property to the `Loader` component. It tells the core class to use the function returning a constant instead of `Math.random`.