### PR TITLE
6 days in a week (Safari)

### DIFF
--- a/components/date-picker/date-picker.css
+++ b/components/date-picker/date-picker.css
@@ -214,6 +214,8 @@
 
   flex-basis: cellSize;
 
+  margin: 0;
+
   cursor: pointer;
   transition: background-color var(--ring-ease), color var(--ring-ease);
   text-align: center;


### PR DESCRIPTION
When viewed in Safari, DatePicker component shows a calendar having 6 days in a week. That's because days are buttons and Safari buttons have extra margin by default. This can be solved by explicitly setting `margin: 0;`