### PR TITLE
the select should not close the parent popup on value change

### DIFF
--- a/components/popup/popup.js
+++ b/components/popup/popup.js
@@ -274,7 +274,7 @@ export default class Popup extends PureComponent {
         this._listenersEnabled = true;
         this.listeners.add(window, 'resize', this._redraw);
         this.listeners.add(window, 'scroll', this._redraw);
-        this.listeners.add(document, 'click', this._onDocumentClick);
+        this.listeners.add(document, 'click', this._onDocumentClick, true);
         let el = this._getAnchor();
         while (el) {
           this.listeners.add(el, 'scroll', this._redraw);


### PR DESCRIPTION
The solution is to revert the click handlers' order by subscribing to the capture phase.