### PR TITLE
A render prop was introduced for date-popup component

### DIFF
--- a/components/date-picker/date-picker.test.js
+++ b/components/date-picker/date-picker.test.js
@@ -80,7 +80,7 @@ describe('Date Picker', () => {
     }
 
     const picker = mountDatePicker({
-      render: customComponent
+      renderAfterCalendar: customComponent
     });
     picker.simulate('click');
 

--- a/components/date-picker/date-picker.test.js
+++ b/components/date-picker/date-picker.test.js
@@ -66,4 +66,24 @@ describe('Date Picker', () => {
     picker.simulate('click');
     document.body.should.contain(`.${styles.datePopup}`);
   });
+
+  it('should display in the popup the component passed through its render prop', () => {
+    function customComponent() {
+      return (
+        <button
+          className="btn-today"
+          type="button"
+        >
+          {'Today'}
+        </button>
+      );
+    }
+
+    const picker = mountDatePicker({
+      render: customComponent
+    });
+    picker.simulate('click');
+
+    document.body.querySelector('.btn-today').should.have.text('Today');
+  });
 });

--- a/components/date-picker/date-popup.js
+++ b/components/date-picker/date-popup.js
@@ -33,7 +33,7 @@ export default class DatePopup extends Component {
     time: PropTypes.string,
     from: dateType,
     to: dateType,
-    render: PropTypes.func,
+    renderAfterCalendar: PropTypes.func,
     displayFormat: PropTypes.func,
     parseDateInput: PropTypes.func,
     onChange: PropTypes.func,
@@ -394,7 +394,7 @@ export default class DatePopup extends Component {
           <Years {...calendarProps}/>
         </div>
 
-        {this.props.render && this.props.render(this.state)}
+        {this.props.renderAfterCalendar && this.props.renderAfterCalendar(this.state)}
       </div>
     );
   }

--- a/components/date-picker/date-popup.js
+++ b/components/date-picker/date-popup.js
@@ -33,6 +33,7 @@ export default class DatePopup extends Component {
     time: PropTypes.string,
     from: dateType,
     to: dateType,
+    render: PropTypes.func,
     displayFormat: PropTypes.func,
     parseDateInput: PropTypes.func,
     onChange: PropTypes.func,
@@ -392,6 +393,8 @@ export default class DatePopup extends Component {
           />
           <Years {...calendarProps}/>
         </div>
+
+        {this.props.render && this.props.render(this.state)}
       </div>
     );
   }


### PR DESCRIPTION
Sometimes it is necessary to involve specific components into the date popup. For example, buttons with relative periods (or dates) such as Today, Yesterday, Last Month, etc. We should not foresee all possible scenarios and visual interpretations, but at least we ought to give the possibility of displaying them.
I solve the issue using render props