### PR TITLE
Support dark overlay background for the table

### DIFF
--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -108,6 +108,7 @@
   --ring-button-loader-background: rgb(var(--ring-button-loader-background-components)); /* #33a3ff */
   --ring-button-primary-background-components: 26, 152, 255;
   --ring-button-primary-background-color: rgb(var(--ring-button-primary-background-components)); /* #1a98ff */
+  --ring-table-loader-background-color: rgba(var(--ring-content-background-components), 0.5); /* #ffffff80 */
 
   /* Code */
   --ring-code-background-color: var(--ring-content-background-color);

--- a/src/global/variables_dark.css
+++ b/src/global/variables_dark.css
@@ -90,6 +90,7 @@
   --ring-button-danger-active-color: rgb(var(--ring-button-danger-active-components)); /* #26080a */
   --ring-button-primary-background-components: 0, 126, 229;
   --ring-button-primary-background-color: rgb(var(--ring-button-primary-background-components)); /* #007ee5 */
+  --ring-table-loader-background-color: rgba(var(--ring-content-background-components), 0.5); /* #23272b80 */
 
   /* Code */
   --ring-code-background-components: 43, 43, 43;

--- a/src/table/table.css
+++ b/src/table/table.css
@@ -165,7 +165,7 @@
   align-items: center;
   justify-content: center;
 
-  background-color: rgba(255, 255, 255, 0.5);
+  background-color: var(--ring-table-loader-background-color);
 }
 
 .cell {


### PR DESCRIPTION
This issue is related to the ones from the YouTrack ([Link](https://youtrack.jetbrains.com/issue/RG-2192/Dark-theme-remove-white-background-in-the-table-loader))

Before:
Table loading overlay had a hardcoded background color.

Now:
This overlay has a color which depends on the content color. This changes nothing when it comes to the Light theme. But now in the dark theme it has a proper dark color instead of a hardcoded white color.