### PR TITLE
RG-2276 update API of translation layer to meet requirements

### DIFF
--- a/src/auth/auth__core.ts
+++ b/src/auth/auth__core.ts
@@ -4,7 +4,7 @@ import HTTP, {HTTPAuth, RequestParams} from '../http/http';
 import promiseWithTimeout from '../global/promise-with-timeout';
 import AuthDialogService from '../auth-dialog-service/auth-dialog-service';
 
-import {getTranslations} from '../i18n/i18n';
+import {getTranslations, getTranslationsWithFallback, translate} from '../i18n/i18n';
 
 import AuthStorage, {AuthState} from './storage';
 import AuthResponseParser, {AuthError} from './response-parser';
@@ -68,7 +68,7 @@ export interface LoginFlowClass {
   new (
     requestBuilder: AuthRequestBuilder,
     storage: AuthStorage,
-    translations: AuthTranslations,
+    translations: AuthTranslations
   ): LoginFlow
 }
 
@@ -269,7 +269,7 @@ export default class Auth implements HTTPAuth {
       this._embeddedFlow = new this.config.EmbeddedLoginFlow(
         this._requestBuilder,
         this._storage,
-        this.config.translations ?? getTranslations()
+        this.config.translations ?? getTranslationsWithFallback()
       );
     }
 
@@ -753,7 +753,6 @@ export default class Auth implements HTTPAuth {
 
   _showUserChangedDialog({newUser, onApply, onPostpone}: UserChangedDialogParams) {
     const {translations} = this.config;
-    const actualTranslations = translations ?? getTranslations();
 
     this._createInitDeferred();
 
@@ -765,14 +764,14 @@ export default class Auth implements HTTPAuth {
 
     const hide = this._authDialogService?.({
       ...this._service,
-      title: actualTranslations.youHaveLoggedInAs.
+      title: translations?.youHaveLoggedInAs ?? translate('youHaveLoggedInAs').
         replace('%userName%', newUser.name ?? '').
         replace('{{userName}}', newUser.name ?? ''),
-      loginCaption: actualTranslations.login,
-      loginToCaption: actualTranslations.loginTo,
-      confirmLabel: actualTranslations.applyChange,
-      tryAgainLabel: actualTranslations.tryAgainLabel,
-      cancelLabel: actualTranslations.postpone,
+      loginCaption: translations?.login ?? translate('login'),
+      loginToCaption: translations?.loginTo ?? translate('loginTo'),
+      confirmLabel: translations?.applyChange ?? translate('applyChange'),
+      tryAgainLabel: translations?.tryAgainLabel ?? translate('tryAgainLabel'),
+      cancelLabel: translations?.postpone ?? translate('postpone'),
       onConfirm: () => {
         done();
         onApply();
@@ -844,7 +843,8 @@ export default class Auth implements HTTPAuth {
       };
 
       const hide = onBackendDown({
-        onCheckAgain, onPostpone, backendError, translations: translations ?? getTranslations()
+        onCheckAgain, onPostpone, backendError,
+        translations: translations ?? getTranslationsWithFallback()
       });
 
       window.addEventListener('online', onCheckAgain);

--- a/src/header/profile.tsx
+++ b/src/header/profile.tsx
@@ -20,7 +20,6 @@ import {AuthUser} from '../auth/auth';
 import {isTruthy} from '../global/typescript-utils';
 
 import {ClickableLinkProps} from '../link/clickableLink';
-import {Messages} from '../i18n/i18n';
 
 import styles from './header.css';
 
@@ -101,7 +100,7 @@ export default class Profile extends PureComponent<ProfileProps> {
     size: Size.Size32,
     renderGuest: ({loading, onLogin, className, translations}) => (
       <I18nContext.Consumer>
-        {messages => (
+        {({translate}) => (
           <div
             className={classNames(styles.profileEmpty, className)}
           >
@@ -112,7 +111,7 @@ export default class Profile extends PureComponent<ProfileProps> {
               loader={loading}
               onClick={onLogin}
             >
-              {translations?.login ?? messages.login}
+              {translations?.login ?? translate('login')}
             </Button>
           </div>
         )}
@@ -121,6 +120,7 @@ export default class Profile extends PureComponent<ProfileProps> {
   };
 
   static contextType = I18nContext;
+  declare context: React.ContextType<typeof Profile.contextType>;
 
   static Size = Size;
 
@@ -148,7 +148,7 @@ export default class Profile extends PureComponent<ProfileProps> {
       ...props
     } = this.props;
 
-    const messages = this.context as Messages;
+    const {translate} = this.context;
 
     if (!user) {
       return (
@@ -182,19 +182,19 @@ export default class Profile extends PureComponent<ProfileProps> {
     const items = [
       showApplyChangedUser && {
         rgItemType,
-        label: translations?.applyChangedUser ?? messages.applyChangedUser,
+        label: translations?.applyChangedUser ?? translate('applyChangedUser'),
         className: styles.profileMenuItem,
         onClick: onRevertPostponement
       },
       showLogIn && {
         rgItemType,
-        label: translations?.login ?? messages.login,
+        label: translations?.login ?? translate('login'),
         className: styles.profileMenuItem,
         onClick: onRevertPostponement
       },
       {
         rgItemType: PopupMenu.ListProps.Type.LINK,
-        label: translations?.profile ?? messages.profile,
+        label: translations?.profile ?? translate('profile'),
 
         target: '_self', // Full page reload in Angular
         href: profileUrl,
@@ -202,13 +202,13 @@ export default class Profile extends PureComponent<ProfileProps> {
       },
       showSwitchUser && {
         rgItemType,
-        label: translations?.switchUser ?? messages.switchUser,
+        label: translations?.switchUser ?? translate('switchUser'),
         className: styles.profileMenuItem,
         onClick: onSwitchUser
       },
       showLogOut && {
         rgItemType,
-        label: translations?.logout ?? messages.logout,
+        label: translations?.logout ?? translate('logout'),
 
         onClick: onLogout
       }

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -16,7 +16,7 @@ const localised = {
 2. Pass it to i18n singleton, using `setTranslations`. That would provide localisation to non-react components, like Auth.
 
 ```
-// Your messages object should have loalised strings at that moment
+// Your messages object should have localised strings at that moment
 const localised = {
   login: 'Inloggen',
   ...

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -25,10 +25,7 @@ const localised = {
 setTranslations(localised);
 ```
 
-3. [Optional] Add I18nContextHolder into your root tree. 
-   If you skip this step, messages from singleton service would be used.
-   Note: setTranslations() calls won't cause React tree rerender, so you have to call it before first render.
-   If you need to live update your strings, you need to use I18nContextHolder. 
+3. Add I18nContextHolder into your root React tree. If you replace "localised" object with another one, consumers would be updated automatically.  
 
 ```
   <I18nContextHolder messages={localised}>

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -1,3 +1,49 @@
 This is localisation layer, that allows to translate the app into different languages.
 
 All messages should be stored in a messages.json, using that format https://www.i18next.com/misc/json-format#i18next-json-v4
+
+### How to use
+
+1. Using your project i18n tooling, construct an object with localised messages, like:
+```
+// You can use https://ttag.js.org/ for example:
+const localised = {
+  login: t`Log in`,
+  ...
+}
+```
+
+2. Pass it to i18n singleton, using `setTranslations`. That would provide localisation to non-react components, like Auth.
+
+```
+// Your messages object should have loalised strings at that moment
+const localised = {
+  login: 'Inloggen',
+  ...
+}
+
+setTranslations(localised);
+```
+
+3. [Optional] Add I18nContextHolder into your root tree. 
+   If you skip this step, messages from singleton service would be used.
+   Note: setTranslations() calls won't cause React tree rerender, so you have to call it before first render.
+   If you need to live update your strings, you need to use I18nContextHolder. 
+
+```
+  <I18nContextHolder messages={localised}>
+    <App />
+  </I18nContextHolder>
+```  
+
+
+
+### Utilities
+
+There is some ways to automate strings extraction from messages.json. You can do:
+
+```
+npx i18next-conv -s messages.json -t messages.pot -l en --ctxSeparator "|" --compatibilityJSON v4
+```
+
+And get a .pot file, which you can merge with your other sources

--- a/src/i18n/i18n-context.ts
+++ b/src/i18n/i18n-context.ts
@@ -1,5 +1,0 @@
-import React from 'react';
-
-import {getTranslations, type Messages} from './i18n';
-
-export const I18nContext = React.createContext<Messages>(getTranslations());

--- a/src/i18n/i18n-context.tsx
+++ b/src/i18n/i18n-context.tsx
@@ -1,0 +1,31 @@
+import React, {useEffect} from 'react';
+
+import {getTranslations, type Messages, setTranslations, translate} from './i18n';
+
+interface I18nContextProps {
+  translate(key: keyof Messages): string;
+  messages: Messages;
+}
+
+export const I18nContext = React.createContext<I18nContextProps>({
+  messages: getTranslations(),
+  translate
+});
+
+
+interface I18nContextHolderProps {
+  messages: Messages;
+  children?: React.ReactNode
+}
+
+export const I18nContextHolder: React.FC<I18nContextHolderProps> = ({children, messages}) => {
+  useEffect(() => {
+    setTranslations(messages);
+  }, [messages]);
+
+  return (
+    <I18nContext.Provider value={{messages, translate}}>
+      {children}
+    </I18nContext.Provider>
+  );
+};

--- a/src/i18n/i18n-context.tsx
+++ b/src/i18n/i18n-context.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 
 import {getTranslations, type Messages, setTranslations, translate} from './i18n';
 
-interface I18nContextProps {
+export interface I18nContextProps {
   translate(key: keyof Messages): string;
   messages: Messages;
 }

--- a/src/i18n/i18n.examples.tsx
+++ b/src/i18n/i18n.examples.tsx
@@ -5,19 +5,19 @@ import {Story} from '@storybook/react';
 
 import reactDecorator from '../../.storybook/react-decorator';
 
-import {getTranslations, Messages} from './i18n';
-import {I18nContext} from './i18n-context';
+import {getTranslations, type Messages} from './i18n';
+import {I18nContext, I18nContextHolder} from './i18n-context';
 
 const I18nTestComponent: React.FC<Messages> = props => (
-  <I18nContext.Provider value={props}>
+  <I18nContextHolder messages={props}>
     <I18nContext.Consumer>
-      {messages => (
-        Object.entries(messages).map(([key, value]) => (
-          <div key={key}>{key}: {value}</div>
+      {({messages, translate}) => (
+        Object.keys(messages).map(key => (
+          <div key={key}>{key}: {translate(key as keyof Messages)}</div>
         ))
       )}
     </I18nContext.Consumer>
-  </I18nContext.Provider>
+  </I18nContextHolder>
 );
 
 export default {

--- a/src/i18n/i18n.test.ts
+++ b/src/i18n/i18n.test.ts
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+
+import defaultMessages from './messages.json';
+import {translate, getTranslationsWithFallback, getTranslations, setTranslations} from './i18n';
+
+describe('i18n singleton', () => {
+  let consoleWarnStub: sinon.SinonStub;
+  beforeEach(() => {
+    sandbox.stub(console, 'warn');
+    // eslint-disable-next-line no-console
+    consoleWarnStub = console.warn as sinon.SinonStub;
+  });
+
+  afterEach(() => {
+    consoleWarnStub.restore();
+    setTranslations(defaultMessages);
+  });
+
+  it('should return the value for an existing key', () => {
+    setTranslations({login: 'bar'});
+    const result = translate('login');
+    result.should.equal('bar');
+  });
+
+  it('should log a warning for a missing key', () => {
+    setTranslations({login: 'bar'});
+    translate('filterItems');
+    consoleWarnStub.calledOnce.should.be.true;
+    consoleWarnStub.firstCall.args[0].should.equal('Missing localisation for key "filterItems"');
+  });
+
+  it('should log a warning only once for a missing key', () => {
+    setTranslations({login: 'bar'});
+    translate('decline');
+    translate('decline');
+    consoleWarnStub.calledOnce.should.be.true;
+  });
+
+  it('should return a merged object with the translations and default messages', () => {
+    setTranslations({logout: 'bar'});
+    const result = getTranslationsWithFallback();
+    result.login.should.equal(defaultMessages.login);
+    result.logout.should.equal('bar');
+  });
+
+  it('should return the current translations object', () => {
+    setTranslations({login: 'bar'});
+    const result = getTranslations();
+    result.should.deep.equal({login: 'bar'});
+  });
+});

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -26,7 +26,7 @@ export function getTranslations() {
 }
 
 export function getTranslationsWithFallback(): MessagesStrict {
-  return {...messages, ...defaultMessages};
+  return {...defaultMessages, ...messages};
 }
 
 export function translate(key: keyof MessagesStrict): string {

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -25,6 +25,10 @@ export function getTranslations() {
   return messages;
 }
 
+export function getTranslationsWithFallback(): MessagesStrict {
+  return {...messages, ...defaultMessages};
+}
+
 export function translate(key: keyof MessagesStrict): string {
   if (!(key in messages)) {
     warnMissedKeyOnce(key);

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,8 +1,21 @@
 import defaultMessages from './messages.json';
 
-export type Messages = typeof defaultMessages;
+export type MessagesStrict = typeof defaultMessages;
 
-let messages = defaultMessages;
+export type Messages = Partial<MessagesStrict>;
+
+let messages: Messages = defaultMessages;
+
+function warnMissedKeyOnce(key: keyof MessagesStrict) {
+  const warned = new Set<string>();
+  if (warned.has(key)) {
+    return;
+  }
+
+  warned.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(`Missing localisation for key "${key}"`);
+}
 
 export function setTranslations(newMessages: Messages) {
   messages = newMessages;
@@ -10,4 +23,11 @@ export function setTranslations(newMessages: Messages) {
 
 export function getTranslations() {
   return messages;
+}
+
+export function translate(key: keyof MessagesStrict): string {
+  if (!(key in messages)) {
+    warnMissedKeyOnce(key);
+  }
+  return messages[key] ?? defaultMessages[key];
 }

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -5,9 +5,9 @@ export type MessagesStrict = typeof defaultMessages;
 export type Messages = Partial<MessagesStrict>;
 
 let messages: Messages = defaultMessages;
+const warned = new Set<string>();
 
 function warnMissedKeyOnce(key: keyof MessagesStrict) {
-  const warned = new Set<string>();
   if (warned.has(key)) {
     return;
   }

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -220,7 +220,7 @@ export class Input extends PureComponent<InputProps> {
 
     return (
       <I18nContext.Consumer>
-        {messages => (
+        {({translate}) => (
           <div className={classes} data-test="ring-input">
             {label && (
               <InputLabel
@@ -249,7 +249,7 @@ export class Input extends PureComponent<InputProps> {
                 )}
               {clearable && !disabled && (
                 <Button
-                  title={(translations ?? messages).clear}
+                  title={translations?.clear ?? translate('clear')}
                   data-test="ring-input-clear"
                   className={styles.clear}
                   icon={closeIcon}

--- a/src/message/message.tsx
+++ b/src/message/message.tsx
@@ -154,7 +154,7 @@ export default class Message extends Component<MessageProps> {
 
     return (
       <I18nContext.Consumer>
-        {messages => (
+        {({translate}) => (
           <WithThemeClasses theme={theme}>
             {themeClasses => (
               <Popup
@@ -183,10 +183,12 @@ export default class Message extends Component<MessageProps> {
                       onClick={onClose}
                       primary
                       {...buttonProps}
-                    >{(translations ?? messages).gotIt}</Button>
+                    >{translations?.gotIt ?? translate('gotIt')}</Button>
                   )}
                   {onDismiss && (
-                    <Button onClick={onDismiss} text>{(translations ?? messages).dismiss}</Button>
+                    <Button onClick={onDismiss} text>
+                      {translations?.dismiss ?? translate('dismiss')}
+                    </Button>
                   )}
                 </ThemeProvider>
               </Popup>

--- a/src/pager/pager.test.tsx
+++ b/src/pager/pager.test.tsx
@@ -3,13 +3,18 @@ import {shallow, mount} from 'enzyme';
 
 import ButtonToolbar from '../button-toolbar/button-toolbar';
 
+import {I18nContextHolder} from '../i18n/i18n-context';
+
 import Pager, {PagerAttrs} from './pager';
 import styles from './pager.css';
 
 describe('Pager', () => {
   const props = {total: 100, currentPage: 1, onPageChange: () => {}};
   const shallowPager = (params?: Partial<PagerAttrs>) =>
-    shallow(<Pager {...{...props, ...params}}/>);
+    shallow(
+      <I18nContextHolder messages={{}}>
+        <Pager {...{...props, ...params}}/>
+      </I18nContextHolder>);
   const mountPager = (params?: Partial<PagerAttrs>) => mount(<Pager {...{...props, ...params}}/>);
 
   it('should create component', () => {
@@ -17,7 +22,7 @@ describe('Pager', () => {
   });
 
   it('should render page buttons when total is more than pageSize', () => {
-    const wrapper = shallowPager({
+    const wrapper = mountPager({
       total: 2,
       pageSize: 1
     });
@@ -32,9 +37,11 @@ describe('Pager', () => {
   });
 
   it('should render page size selector even when total is less than 2', () => {
-    const wrapper = shallowPager({total: 1});
+    const wrapper = mountPager({total: 1});
     wrapper.should.have.data('test', 'ring-pager');
-    wrapper.childAt(0).should.have.data('test', 'ring-pager-page-size-selector');
+    should.exist(
+      wrapper.getDOMNode()?.querySelector('[data-test^=ring-pager-page-size-selector]')
+    );
   });
 
   it('should wrap children with div', () => {
@@ -42,11 +49,11 @@ describe('Pager', () => {
   });
 
   it('should use passed className', () => {
-    shallowPager({className: 'test-class'}).should.have.className('test-class');
+    shallowPager({className: 'test-class'}).find(Pager).should.have.className('test-class');
   });
 
   it('should render page buttons even when currentPage==total if openTotal is true', () => {
-    const wrapper = shallowPager({
+    const wrapper = mountPager({
       total: 10,
       pageSize: 10,
       currentPage: 1,

--- a/src/pager/pager.tsx
+++ b/src/pager/pager.tsx
@@ -16,7 +16,6 @@ import Link, {WrapTextProps} from '../link/link';
 import Icon from '../icon/icon';
 
 import {I18nContext} from '../i18n/i18n-context';
-import {Messages} from '../i18n/i18n';
 
 import style from './pager.css';
 
@@ -69,12 +68,14 @@ export default class Pager extends PureComponent<PagerProps> {
 
   static contextType = I18nContext;
 
+  declare context: React.ContextType<typeof Pager.contextType>;
+
   getSelectOptions() {
     const {pageSize, pageSizes} = this.props;
-    const messages = this.context as Messages;
+    const {translate} = this.context;
     const data: SelectItem<PagerSizeItem>[] = pageSizes.map(size => ({
       key: size,
-      label: `${size} ${(this.props.translations ?? messages).perPage}`
+      label: `${size} ${this.props.translations?.perPage ?? translate('perPage')}`
     }));
     const selected = data.find(it => it.key === pageSize);
     return {selected, data};
@@ -164,7 +165,7 @@ export default class Pager extends PureComponent<PagerProps> {
   }
 
   getPagerLinks() {
-    const messages = this.context as Messages;
+    const {translate} = this.context;
 
     const prevLinkAvailable = this.props.currentPage !== 1;
 
@@ -179,9 +180,9 @@ export default class Pager extends PureComponent<PagerProps> {
       <Icon glyph={chevronLeftIcon} key="icon"/>
     );
 
-    const prevText = (this.props.translations ?? messages).previousPage;
+    const prevText = this.props.translations?.previousPage ?? translate('previousPage');
 
-    const nextText = (this.props.translations ?? messages).nextPage;
+    const nextText = this.props.translations?.nextPage ?? translate('nextPage');
 
     const nextLinkContent = (WrapText: ComponentType<WrapTextProps>) => [
       <span key="text"><WrapText>{nextText}</WrapText></span>,
@@ -248,7 +249,7 @@ export default class Pager extends PureComponent<PagerProps> {
   getPagerContent() {
     const {currentPage, visiblePagesLimit} = this.props;
     const totalPages = this.getTotalPages();
-    const messages = this.context as Messages;
+    const {translate} = this.context;
 
     if (totalPages < this.props.currentPage) {
       this.props.onPageChange?.(totalPages);
@@ -295,7 +296,8 @@ export default class Pager extends PureComponent<PagerProps> {
         {this.getPagerLinks()}
 
         <ButtonToolbar>
-          {start > 1 && this.getButton(1, (this.props.translations ?? messages).firstPage)}
+          {start > 1 &&
+            this.getButton(1, this.props.translations?.firstPage ?? translate('firstPage'))}
 
           <ButtonGroup>
             {start > 1 && this.getButton(start - 1, '...')}
@@ -315,7 +317,7 @@ export default class Pager extends PureComponent<PagerProps> {
 
           {lastPageButtonAvailable && this.getButton(
             this.props.openTotal ? -1 : totalPages,
-            (this.props.translations ?? messages).lastPage
+            this.props.translations?.lastPage ?? translate('lastPage')
           )}
         </ButtonToolbar>
 

--- a/src/query-assist/query-assist.tsx
+++ b/src/query-assist/query-assist.tsx
@@ -1016,11 +1016,11 @@ export default class QueryAssist extends Component<QueryAssistProps> {
     if (renderClear) {
       actions.push(
         <I18nContext.Consumer key={'clearAction'}>
-          {messages => (
+          {({translate}) => (
             <Button
               icon={closeIcon}
               className={styles.clear}
-              title={(this.props.translations ?? messages).clearTitle}
+              title={this.props.translations?.clearTitle ?? translate('clearTitle')}
               ref={this.clearRef}
               onClick={this.clearQuery}
               data-test="query-assist-clear-icon"
@@ -1066,7 +1066,7 @@ export default class QueryAssist extends Component<QueryAssistProps> {
     return (
       <ControlsHeightContext.Provider value={ControlsHeight.M}>
         <I18nContext.Consumer>
-          {messages => (
+          {({translate}) => (
             <div
               data-test={dataTests('ring-query-assist', dataTest)}
               className={containerClasses}
@@ -1084,7 +1084,7 @@ export default class QueryAssist extends Component<QueryAssistProps> {
                 <Icon
                   glyph={searchIcon}
                   className={styles.icon}
-                  title={(translations ?? messages).searchTitle}
+                  title={translations?.searchTitle ?? translate('searchTitle')}
                   ref={this.glassRef}
                   data-test="query-assist-search-icon"
                 />
@@ -1103,7 +1103,7 @@ export default class QueryAssist extends Component<QueryAssistProps> {
               )}
 
               <ContentEditable
-                aria-label={(translations ?? messages).searchTitle}
+                aria-label={translations?.searchTitle ?? translate('searchTitle')}
                 className={inputClasses}
                 data-test="ring-query-assist-input"
                 inputRef={this.inputRef}
@@ -1169,7 +1169,7 @@ export default class QueryAssist extends Component<QueryAssistProps> {
                   <Icon
                     glyph={searchIcon}
                     className={styles.rightSearchIcon}
-                    title={(translations ?? messages).searchTitle}
+                    title={translations?.searchTitle ?? translate('searchTitle')}
                     onClick={this.handleApply}
                     ref={this.glassRef}
                     data-test="query-assist-search-icon"

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -703,13 +703,13 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
 
     return (
       <I18nContext.Consumer>
-        {messages => {
+        {({translate}) => {
           let message;
 
           if (this.props.loading) {
-            message = this.props.loadingMessage ?? messages.loading;
+            message = this.props.loadingMessage ?? translate('loading');
           } else if (!shownData.length) {
-            message = this.props.notFoundMessage ?? messages.noOptionsFound;
+            message = this.props.notFoundMessage ?? translate('noOptionsFound');
           }
 
           return (

--- a/src/select/select__filter.tsx
+++ b/src/select/select__filter.tsx
@@ -52,10 +52,10 @@ export default class SelectFilter extends Component<SelectFilterProps> {
       <ActiveItemContext.ValueContext.Consumer>
         {activeItemId => (
           <I18nContext.Consumer>
-            {messages => (
+            {({translate}) => (
               <Input
                 {...restProps}
-                placeholder={restProps.placeholder ?? messages.filterItems}
+                placeholder={restProps.placeholder ?? translate('filterItems')}
                 aria-owns={listId}
                 aria-activedescendant={activeItemId}
                 autoComplete="off"

--- a/src/user-agreement/user-agreement.tsx
+++ b/src/user-agreement/user-agreement.tsx
@@ -90,9 +90,9 @@ export default class UserAgreement extends PureComponent<UserAgreementProps> {
 
     return (
       <I18nContext.Consumer>
-        {messages => (
+        {({translate}) => (
           <Dialog
-            label={(translations ?? messages).userAgreement}
+            label={translations?.userAgreement ?? translate('userAgreement')}
             show={show}
             className={classNames(style.agreementDialog, className)}
             contentClassName={style.dialogContent}
@@ -100,7 +100,7 @@ export default class UserAgreement extends PureComponent<UserAgreementProps> {
             autoFocusFirst={false}
             data-test="user-agreement"
           >
-            <Header>{(translations ?? messages).userAgreement}</Header>
+            <Header>{translations?.userAgreement ?? translate('userAgreement')}</Header>
             <Content
               fade
               onScrollToBottom={this.onScrollToBottom}
@@ -111,19 +111,19 @@ export default class UserAgreement extends PureComponent<UserAgreementProps> {
               <Panel>
                 {onRemindLater && !scrolledDown && (
                   <div className={style.suggestion}>
-                    {(translations ?? messages).scrollToAccept}
+                    {translations?.scrollToAccept ?? translate('scrollToAccept')}
                   </div>
                 )}
                 <Button primary disabled={!scrolledDown} onClick={onAccept} data-test="accept">
-                  {(translations ?? messages).accept}
+                  {translations?.accept ?? translate('accept')}
                 </Button>
                 <Button onClick={onDecline} autoFocus data-test="decline">
-                  {(translations ?? messages).decline}
+                  {translations?.decline ?? translate('decline')}
                 </Button>
 
                 {!onRemindLater && !scrolledDown && (
                   <span className={style.suggestion}>
-                    {(translations ?? messages).scrollToAccept}
+                    {translations?.scrollToAccept ?? translate('scrollToAccept')}
                   </span>
                 )}
                 {onRemindLater && (
@@ -132,7 +132,7 @@ export default class UserAgreement extends PureComponent<UserAgreementProps> {
                     onClick={onRemindLater}
                     data-test="later"
                   >
-                    {(translations ?? messages).remindLater}
+                    {translations?.remindLater ?? translate('remindLater')}
                   </Button>
                 )}
               </Panel>
@@ -140,7 +140,7 @@ export default class UserAgreement extends PureComponent<UserAgreementProps> {
             {preview && (
               <Panel>
                 <Button onClick={onClose} autoFocus data-test="close">
-                  {(translations ?? messages).close}
+                  {translations?.close ?? translate('close')}
                 </Button>
               </Panel>
             )}

--- a/src/user-card/card.tsx
+++ b/src/user-card/card.tsx
@@ -11,8 +11,6 @@ import Icon, {Size as IconSize} from '../icon/icon';
 
 import {I18nContext} from '../i18n/i18n-context';
 
-import {Messages} from '../i18n/i18n';
-
 import styles from './user-card.css';
 
 export interface UserCardUser {
@@ -77,23 +75,23 @@ export default class UserCard extends PureComponent<UserCardProps> {
   };
 
   static contextType = I18nContext;
+  declare context: React.ContextType<typeof UserCard.contextType>;
 
   copyEmail = () => {
-    const messages = this.context as Messages;
-    const messageOverrides = this.props.wording || this.props.translations;
+    const {translate} = this.context;
+    const wording = this.props.translations || this.props.wording;
 
-    const wording = messageOverrides ?? messages;
     clipboard.copyText(
-      this.props.user.email || '', wording.copiedToClipboard, wording.copingToClipboardError
+      this.props.user.email || '',
+      wording?.copiedToClipboard ?? translate('copyToClipboard'),
+      wording?.copingToClipboardError ?? translate('copingToClipboardError')
     );
   };
 
   render() {
     const {children, info, className, user, avatarInfo, ...restProps} = this.props;
-    const messages = this.context as Messages;
-    const messageOverrides = this.props.wording || this.props.translations;
-
-    const wording = messageOverrides ?? messages;
+    const {translate} = this.context;
+    const wording = this.props.translations || this.props.wording;
 
     const classes = classNames(className, {});
     const userActiveStatusClasses = classNames(
@@ -129,7 +127,10 @@ export default class UserCard extends PureComponent<UserCardProps> {
                   (
                     <span
                       className={userActiveStatusClasses}
-                      title={user.online ? wording.online : wording.offline}
+                      title={user.online
+                        ? (wording?.online ?? translate('online'))
+                        : (wording?.offline ?? translate('offline'))
+                      }
                     />
                   )
                 }
@@ -140,7 +141,7 @@ export default class UserCard extends PureComponent<UserCardProps> {
                     <span
                       className={classNames(badgeStyles.badge, badgeStyles.invalid)}
                       title={user.banReason}
-                    >{wording.banned}</span>
+                    >{wording?.banned ?? translate('banned')}</span>
                   )
                 }
               </div>
@@ -159,11 +160,13 @@ export default class UserCard extends PureComponent<UserCardProps> {
                   </Link>
                   {
                     user.unverifiedEmail && (
-                      <span className={styles.unverifiedLabel}>{wording.unverified}</span>
+                      <span className={styles.unverifiedLabel}>
+                        {wording?.unverified ?? translate('unverified')}
+                      </span>
                     )
                   }
                   <Icon
-                    title={wording.copyToClipboard}
+                    title={wording?.copyToClipboard ?? translate('copyToClipboard')}
                     className={styles.userCopyIcon}
                     onClick={this.copyEmail}
                     glyph={copyIcon}

--- a/src/user-card/user-card.test.tsx
+++ b/src/user-card/user-card.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 
+import {I18nContextHolder} from '../i18n/i18n-context';
+
 import {SmartUserCardTooltip, UserCard, UserCardTooltip} from './user-card';
 import {UserCardAttrs} from './card';
 import {UserCardTooltipAttrs} from './tooltip';
@@ -17,7 +19,9 @@ describe('UserCard', () => {
 
   describe('Card', () => {
     const shallowCard = (props?: Partial<UserCardAttrs>) => shallow(
-      <UserCard user={fakeUser} {...props}/>
+      <I18nContextHolder messages={{}}>
+        <UserCard user={fakeUser} {...props}/>
+      </I18nContextHolder>
     );
     const mountCard = (props?: Partial<UserCardAttrs>) =>
       mount(<UserCard user={fakeUser} {...props}/>);
@@ -41,7 +45,7 @@ describe('UserCard', () => {
     });
 
     it('should use passed className', () => {
-      shallowCard({className: 'test-class'}).should.have.className('test-class');
+      shallowCard({className: 'test-class'}).find(UserCard).should.have.className('test-class');
     });
 
     it('should use pass rest props to dom node', () => {


### PR DESCRIPTION
On our weekly meeting, we've agreed to:

1. Change usages of `message.smth` to some function `getMessage('smth')`, because that adds more centralised control
2. In that `getMessage` function, check if we have that key overriden. If not, print warning
2. On type level, have regular "Optional" type `Messages`, so you can skip some messages, and a dedicated `MessagesStrict` so you can opt-in for strict translations typing
3. Add a dedicated Readme for i18n layer