### PR TITLE
Do not use named JSON imports in Table stories

### DIFF
--- a/src/table/table.stories.tsx
+++ b/src/table/table.stories.tsx
@@ -13,7 +13,7 @@ import Table, {Table as BaseTable, TableAttrs} from './table';
 import MultiTable from './multitable';
 import Selection, {SelectionItem} from './selection';
 import mock from './table.stories.json';
-import {continents, countries} from './table.examples2.json';
+import tableData from './table.examples2.json';
 import {SortParams} from './header-cell';
 
 export default {
@@ -265,8 +265,8 @@ basic.argTypes = {
 };
 basic.storyName = 'basic';
 
-const data1 = continents;
-const data2 = countries;
+const data1 = tableData.continents;
+const data2 = tableData.countries;
 
 class MultiTableDemo extends Component {
   state = {


### PR DESCRIPTION
Named JSON imports are deprecated:
1. https://github.com/webpack/webpack/issues/9246
2. https://github.com/webpack/webpack/pull/9259
3. https://github.com/webpack/webpack.js.org/pull/3141/files#diff-2cfa9614f956cffe79f0110043cb376248298001434e6b267350ba7674e9b0f7R475

<img width="1016" alt="Screenshot 2023-11-09 at 20 00 46" src="https://github.com/JetBrains/ring-ui/assets/153412/032be11a-7925-4d11-b221-32b88b36082f">
