### PR TITLE
Fix non-multiline EditableHeading

### DIFF
--- a/src/editable-heading/editable-heading.tsx
+++ b/src/editable-heading/editable-heading.tsx
@@ -211,6 +211,7 @@ export const EditableHeading = (props: EditableHeadingProps) => {
                     autoFocus={autoFocus}
                     data-test={dataTest}
                     disabled={isSaving}
+                    onChange={onChange}
                     {...restProps}
                     onFocus={onInputFocus}
                     onBlur={onInputBlur}


### PR DESCRIPTION
The problem is in this line of code https://github.com/JetBrains/ring-ui/commit/c93f27c12e49b9ae04fdf9e3d3be01315962af06#diff-5f458fe6db99478c84492a8116000facdf632ac46a84e0b3620208761f6a1837R53. The `onChange` handler is no longer passed to the `<input>` as part of `restProps` https://github.com/JetBrains/ring-ui/commit/c93f27c12e49b9ae04fdf9e3d3be01315962af06#diff-5f458fe6db99478c84492a8116000facdf632ac46a84e0b3620208761f6a1837R214.