### PR TITLE
Add ring-error-message-title data attribute

### DIFF
--- a/src/error-message/error-message.tsx
+++ b/src/error-message/error-message.tsx
@@ -51,7 +51,7 @@ export default class ErrorMessage extends Component<ErrorMessageProps> {
           />
         )}
         <div className={styles.content}>
-          <div className={styles.title}>
+          <div className={styles.title} data-test="ring-error-message-title">
             {code && `${code}:`} {message}
           </div>
           {description && (


### PR DESCRIPTION
It was in the Angular.js component https://github.com/JetBrains/ring-ui/blob/ab8314371d0291adbfa984ad8095b2e64d475d42/src/error-message-ng/error-message-ng.js#L24