### PR TITLE
Make DatePicker dropdownProps prop partial type

### DIFF
--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -87,7 +87,7 @@ export type DatePickerProps = Omit<DatePopupProps, 'translations' | 'parseDateIn
   clear: boolean
   inline: boolean
   popupClassName?: string | null | undefined
-  dropdownProps?: DropdownAttrs
+  dropdownProps?: Partial<DropdownAttrs>
   translations?: DatePickerTranslations | null | undefined,
   displayMonthFormat: (date: Date, locale: Locale | undefined) => string
   displayDayFormat: (date: Date, locale: Locale | undefined) => string


### PR DESCRIPTION
It is used in this way https://github.com/JetBrains/ring-ui/blob/6b7e85253d5c17e326512ea8ecc1eccd9b811371/src/date-picker/date-picker.tsx#L330 so it makes sense to make it partial.