### PR TITLE
Get rid of Partial<Response> in HTTP

### DIFF
--- a/src/http/http.mock.ts
+++ b/src/http/http.mock.ts
@@ -32,11 +32,11 @@ export default class HTTPMock extends HTTP {
       }
     }];
 
-    return {
+    return Promise.resolve({
       status: 200,
       headers: new Headers({'content-type': 'application/json'}),
       json: () => Promise.resolve((this._getResponseForUrl(url) || this.defaultResponse))
-    };
+    } as Response);
   }
 
   respondDefault(response: unknown) {

--- a/src/http/http.test.ts
+++ b/src/http/http.test.ts
@@ -24,8 +24,8 @@ describe('HTTP', () => {
     sandbox.stub(httpInstance, '_fetch').resolves({
       status: OK,
       headers: new Headers({'content-type': 'application/json'}),
-      json: () => fetchResult
-    });
+      json: () => Promise.resolve(fetchResult)
+    } as Response);
   }
 
   beforeEach(function beforeEach() {

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -101,7 +101,7 @@ export default class HTTP implements Partial<HTTPAuth> {
     this.baseUrl = baseUrl;
   };
 
-  _fetch(...args: Parameters<typeof fetch>): Promise<Response> | Partial<Response> {
+  _fetch(...args: Parameters<typeof fetch>): Promise<Response> {
     return fetch(...args);
   }
 
@@ -155,14 +155,14 @@ export default class HTTP implements Partial<HTTPAuth> {
       set(parsedResponse, {headers, ok, redirected, status, statusText, type, url});
   }
 
-  private async _processResponse(response: Partial<Response>) {
-    const contentType = response.headers?.get('content-type');
+  private async _processResponse(response: Response) {
+    const contentType = response.headers.get('content-type');
     const isJson = contentType && contentType.indexOf('application/json') !== -1;
 
-    if (response.status != null && HTTP._isErrorStatus(response.status)) {
+    if (HTTP._isErrorStatus(response.status)) {
       let resJson;
       try {
-        resJson = await (isJson ? response.json?.() : response.text?.());
+        resJson = await (isJson ? response.json() : response.text());
       } catch (err) {
         // noop
       }
@@ -171,7 +171,7 @@ export default class HTTP implements Partial<HTTPAuth> {
     }
 
     try {
-      const parsedResponse = await (isJson ? response.json?.() : {data: await response.text?.()});
+      const parsedResponse = await (isJson ? response.json() : {data: await response.text()});
       this._storeRequestMeta(parsedResponse, response);
       return parsedResponse;
     } catch (err) {


### PR DESCRIPTION
`fetch` cannot return `Partial<Response>` in runtime.