### PR TITLE
Remove Input .noLabel CSS class usage

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -197,7 +197,6 @@ export class Input extends PureComponent<InputProps> {
         [styles.active]: active,
         [styles.error]: error != null,
         [styles.empty]: empty,
-        [styles.noLabel]: !this.props.label,
         [styles.withIcon]: icon != null,
         [styles.clearable]: clearable,
         [styles.borderless]: borderless


### PR DESCRIPTION
It was removed here https://github.com/JetBrains/ring-ui/commit/a45730a8db247a50406f09627c7e6489fe055a7f#diff-9571a6a46f39072419647c7b25d8afcfee0c28f631246b5e8e2bebdb974db8c4L165.