### PR TITLE
Use stable composed ref in Input

### DIFF
--- a/src/global/composeRefs.ts
+++ b/src/global/composeRefs.ts
@@ -1,9 +1,16 @@
 import {Ref, MutableRefObject} from 'react';
+import memoizeOne from 'memoize-one';
 
-export default <T>(...refs: (Ref<T> | undefined)[]) => (value: T | null) => refs.forEach(ref => {
-  if (typeof ref === 'function') {
-    ref(value);
-  } else if (ref != null) {
-    (ref as MutableRefObject<T | null>).current = value;
-  }
-});
+export default function composeRefs<T>(...refs: (Ref<T> | undefined)[]) {
+  return (value: T | null) => refs.forEach(ref => {
+    if (typeof ref === 'function') {
+      ref(value);
+    } else if (ref != null) {
+      (ref as MutableRefObject<T | null>).current = value;
+    }
+  });
+}
+
+export function createComposedRef<T>() {
+  return memoizeOne(composeRefs<T>);
+}

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -20,7 +20,7 @@ import getUID from '../global/get-uid';
 import Icon from '../icon/icon';
 import {I18nContext} from '../i18n/i18n-context';
 
-import composeRefs from '../global/composeRefs';
+import {createComposedRef} from '../global/composeRefs';
 
 import {ControlsHeight, ControlsHeightContext} from '../global/controls-height';
 import {ControlLabel, LabelType} from '../control-label/control-label';
@@ -142,6 +142,8 @@ export class Input extends PureComponent<InputProps> {
     this.input = el;
   };
 
+  composedInputRef = createComposedRef<HTMLInputElement | HTMLTextAreaElement>();
+
   clear = (e: React.MouseEvent<HTMLButtonElement>) => {
     this.props.onClear && this.props.onClear(e);
   };
@@ -211,7 +213,7 @@ export class Input extends PureComponent<InputProps> {
     const text = value != null ? value : children;
 
     const commonProps = {
-      ref: composeRefs(this.inputRef, inputRef),
+      ref: this.composedInputRef(this.inputRef, inputRef),
       className: inputClasses,
       value: text,
       disabled,


### PR DESCRIPTION
The current implementation of `composeRefs` returns a new callback ref each time, so even if a memoized callback ref is passed into `inputRef`, it will still be invoked after every render. To solve this problem, I replace `composeRefs` with a call to a new function `createComposedRef`, which returns a memoized version of `composeRefs`. This is similar to using `useMergeRefs`, `useForkRef`, etc.:
1. https://github.com/mui/material-ui/blob/da4546dc9a606800f898a24553d516997ca57be2/packages/mui-utils/src/useForkRef/useForkRef.ts#L13
2. https://github.com/react-restart/hooks/blob/f249c92c7d67667415455374af8933e9b4d73a69/src/useMergedRefs.ts#L39

I would like to replace all `composeRefs` usages with `createComposedRef` in the future.