### PR TITLE
Use stable composed ref in all components

### DIFF
--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -6,7 +6,7 @@ import minusIcon from '@jetbrains/icons/remove-12px';
 
 import Icon from '../icon/icon';
 import {refObject} from '../global/prop-types';
-import composeRefs from '../global/composeRefs';
+import {createComposedRef} from '../global/composeRefs';
 
 import ControlHelp from '../control-help/control-help';
 
@@ -76,6 +76,8 @@ export default class Checkbox extends PureComponent<CheckboxProps> {
     this.input = el;
   };
 
+  composedInputRef = createComposedRef<HTMLInputElement>();
+
   render() {
     const {
       children,
@@ -105,7 +107,7 @@ export default class Checkbox extends PureComponent<CheckboxProps> {
         <input
           {...restProps}
           data-checked={restProps.checked}
-          ref={composeRefs(this.inputRef, inputRef)}
+          ref={this.composedInputRef(this.inputRef, inputRef)}
           type="checkbox"
           className={classes}
         />

--- a/src/global/focus-sensor-hoc.tsx
+++ b/src/global/focus-sensor-hoc.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {refObject} from './prop-types';
 
-import composeRefs from './composeRefs';
+import {createComposedRef} from './composeRefs';
 
 
 export interface FocusSensorOuterProps<T extends HTMLElement> {
@@ -91,6 +91,8 @@ export default function focusSensorHOC<
       }
     };
 
+    composedRef = createComposedRef<HTMLElement>();
+
     onFocusCapture = ({target}: FocusEvent) => {
       if (this._skipNextCapture) {
         this._skipNextCapture = false;
@@ -132,7 +134,7 @@ export default function focusSensorHOC<
       return (
         <ComposedComponent
           {...rest as JSX.LibraryManagedAttributes<C, P>}
-          innerRef={composeRefs(innerRef, this.onRefUpdate)}
+          innerRef={this.composedRef(innerRef, this.onRefUpdate)}
           focused={this.state.focused}
           onFocusReset={this.onFocusReset}
           onFocusRestore={this.onFocusRestore}

--- a/src/global/rerender-hoc.tsx
+++ b/src/global/rerender-hoc.tsx
@@ -1,6 +1,6 @@
 import {Component, forwardRef, Ref, ForwardedRef} from 'react';
 
-import composeRefs from './composeRefs';
+import {createComposedRef} from './composeRefs';
 
 export interface RerenderableComponent<P, S> extends Component<P, S> {
   node?: HTMLElement | null
@@ -26,8 +26,10 @@ export default function rerenderHOC<P extends {}, C extends Component<P, unknown
   class Rerenderer extends Component<RerendererProps<P, C>, P> {
     state = this.props.props;
 
+    composedRef = createComposedRef<C>();
+
     render() {
-      const ref = composeRefs(this.props.forwardedRef);
+      const ref = this.composedRef(this.props.forwardedRef);
       return (
         <ComposedComponent
           {...this.state}

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -37,7 +37,7 @@ import {ListDataItem} from '../list/consts';
 
 import {Directions} from '../popup/popup.consts';
 
-import composeRefs from '../global/composeRefs';
+import {createComposedRef} from '../global/composeRefs';
 import {refObject} from '../global/prop-types';
 import {isArray} from '../global/typescript-utils';
 
@@ -1250,6 +1250,8 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
     this.filter = el;
   };
 
+  composedFilterRef = createComposedRef<HTMLInputElement>();
+
   getShortcutsMap() {
     return {
       enter: this._onEnter,
@@ -1309,7 +1311,7 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
               autoComplete="off"
               id={this.props.id}
               onClick={this._clickHandler}
-              inputRef={composeRefs(this.filterRef, this.props.filterRef)}
+              inputRef={this.composedFilterRef(this.filterRef, this.props.filterRef)}
               disabled={this.props.disabled}
               value={this.state.filterValue}
               borderless={this.props.type === Type.INPUT_WITHOUT_CONTROLS}

--- a/src/select/select__popup.tsx
+++ b/src/select/select__popup.tsx
@@ -34,7 +34,7 @@ import Button from '../button/button';
 import Text from '../text/text';
 import {ControlsHeight} from '../global/controls-height';
 import {refObject} from '../global/prop-types';
-import composeRefs from '../global/composeRefs';
+import {createComposedRef} from '../global/composeRefs';
 
 import {DEFAULT_DIRECTIONS} from '../popup/popup.consts';
 
@@ -331,7 +331,7 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
             rgShortcutsMap={this.popupFilterShortcutsMap}
 
             value={this.props.filterValue}
-            inputRef={composeRefs(this.filterRef, this.props.filterRef)}
+            inputRef={this.composedFilterRef(this.filterRef, this.props.filterRef)}
             onBlur={this.popupFilterOnBlur}
             onFocus={this.onFilterFocus}
             className="ring-js-shortcuts"
@@ -563,6 +563,8 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
     this.filter = el;
     this.caret = el && new Caret(el);
   };
+
+  composedFilterRef = createComposedRef<HTMLInputElement>();
 
   shortcutsScope = getUID('select-popup-');
   shortcutsMap = {

--- a/src/table/row.tsx
+++ b/src/table/row.tsx
@@ -12,7 +12,7 @@ import Tooltip from '../tooltip/tooltip';
 import dataTests from '../global/data-tests';
 
 import getUID from '../global/get-uid';
-import composeRefs from '../global/composeRefs';
+import {createComposedRef} from '../global/composeRefs';
 
 import {FocusSensorAddProps} from '../global/focus-sensor-hoc';
 
@@ -137,6 +137,8 @@ export default class Row<T extends SelectionItem> extends PureComponent<RowProps
     this.row = el;
   };
 
+  composedRowRef = createComposedRef<HTMLElement>();
+
   render() {
     const {
       item, columns: columnProps, selectable, selected,
@@ -255,7 +257,7 @@ export default class Row<T extends SelectionItem> extends PureComponent<RowProps
     return (
       <tr
         id={this.id}
-        ref={composeRefs(this.rowRef, innerRef)}
+        ref={this.composedRowRef(this.rowRef, innerRef)}
         className={classes}
         tabIndex={0}
         data-test={dataTests('ring-table-row', dataTest)}


### PR DESCRIPTION
This is the follow-up to https://github.com/JetBrains/ring-ui/pull/7458. I am doing the same for all components.