### PR TITLE
Deprecate composeRefs export

### DIFF
--- a/src/global/composeRefs.ts
+++ b/src/global/composeRefs.ts
@@ -1,7 +1,8 @@
 import {Ref, MutableRefObject} from 'react';
 import memoizeOne from 'memoize-one';
+import deprecate from 'util-deprecate';
 
-export default function composeRefs<T>(...refs: (Ref<T> | undefined)[]) {
+function composeRefs<T>(...refs: (Ref<T> | undefined)[]) {
   return (value: T | null) => refs.forEach(ref => {
     if (typeof ref === 'function') {
       ref(value);
@@ -10,6 +11,9 @@ export default function composeRefs<T>(...refs: (Ref<T> | undefined)[]) {
     }
   });
 }
+
+// TODO remove export in 7.0, composeRefs should be used only in createComposedRef and in useComposedRefs in the future
+export default deprecate(composeRefs, 'composeRefs is deprecated and will be removed in 7.0. Use createComposedRef instead.');
 
 export function createComposedRef<T>() {
   return memoizeOne(composeRefs<T>);


### PR DESCRIPTION
This is the follow-up to https://github.com/JetBrains/ring-ui/pull/7475#discussion_r1659095865.