### PR TITLE
RG-2450 Date Picker remains open after pressing Enter (another solution)

### DIFF
--- a/src/date-picker/date-input.tsx
+++ b/src/date-picker/date-input.tsx
@@ -86,7 +86,17 @@ export default class DateInput extends React.PureComponent<DateInputProps> {
   handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onInput(e.currentTarget.value, e.currentTarget.dataset.name as Field);
 
-  handleKeyDown = (e: React.KeyboardEvent) => e.key === 'Enter' && this.props.onConfirm();
+  handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      // We have to prevent the default behavior, because restoring focus by TabTrap caused by
+      // pressing Enter will trigger the onClick event on the DatePicker Dropdown anchor,
+      // so DatePicker will be open again.
+      // https://youtrack.jetbrains.com/issue/RG-2450/Anchor-should-be-focused-after-closing-datepicker#focus=Comments-27-10044234.0-0.
+      e.preventDefault();
+
+      this.props.onConfirm();
+    }
+  };
 
   render() {
     const {

--- a/src/tab-trap/tab-trap.tsx
+++ b/src/tab-trap/tab-trap.tsx
@@ -103,16 +103,11 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap({
       previousFocusedNode.focus &&
       isNodeInVisiblePartOfPage(previousFocusedNode)
     ) {
-      // If no delay is added, restoring focus caused by pressing Enter will trigger
-      // the onClick event on the previousFocusedNode, e.g.
-      // https://youtrack.jetbrains.com/issue/RG-2450/Anchor-should-be-focused-after-closing-datepicker#focus=Comments-27-10044234.0-0.
-      setTimeout(() => {
-        // This is to prevent the focus from being restored the first time
-        // componentWillUnmount is called in StrictMode.
-        if (!mountedRef.current) {
-          previousFocusedNode.focus({preventScroll: true});
-        }
-      });
+      // This is to prevent the focus from being restored the first time
+      // componentWillUnmount is called in StrictMode.
+      if (!mountedRef.current) {
+        previousFocusedNode.focus({preventScroll: true});
+      }
     }
   }
 


### PR DESCRIPTION
This is the follow-up to https://github.com/JetBrains/ring-ui/pull/7491.

The previous solution with `setTimeout` led to another problem: because focus is not restored immediately, `TabTrap` can steal focus from another component (see video). So I removed `setTimeout` and tried to solve the problem with Enter in `DatePicker` itself. 

https://github.com/JetBrains/ring-ui/assets/153412/8f2aeaaf-3473-4609-80e4-1c2caa40e6fa

