### PR TITLE
Make Toggle root element inline

### DIFF
--- a/src/toggle/toggle.css
+++ b/src/toggle/toggle.css
@@ -5,7 +5,7 @@
 @value timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 
 .toggle {
-  display: flex;
+  display: inline-flex;
   align-items: baseline;
 
   cursor: pointer;


### PR DESCRIPTION
Previously, the root element of the Toggle component was inline (because the default value of the `display` property of the `<label>` HTML element is `inline`). [Here](https://github.com/JetBrains/ring-ui/commit/f9ef698d7cd8e544ed1c220e4c5e57692e1eaa2b#diff-7219d926853aafb9e6afd73c588cbd06fd42c041aa7ab7f770e916ee3629419fR8) `display: flex` has been applied to this label, and it is actually a breaking change because then the `<label>` element has become block.

This change will fix at least 4 broken layout bugs on YouTrack https://youtrack.jetbrains.com/issue/JT-82959.