### PR TITLE
RG-2293 Get rid of side effects in setState updater function of Select

### DIFF
--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -1012,16 +1012,9 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
 
         if (!prevState.multipleMap[selected.key]) {
           nextSelection = currentSelection.concat(selected);
-          this.props.onSelect && this.props.onSelect(selected, event);
         } else {
           nextSelection = currentSelection.filter(item => item.key !== selected.key);
-          this.props.onDeselect && this.props.onDeselect(selected);
         }
-
-        (this.props.onChange as (selected: SelectItem<T>[], event?: Event) => void)(
-          nextSelection,
-          event
-        );
 
         const nextState: Partial<SelectState<T>> = {
           filterValue: '',
@@ -1049,6 +1042,17 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
         return {...prevState, ...nextState};
 
       }, () => {
+        if (this.state.multipleMap[selected.key]) {
+          this.props.onSelect?.(selected, event);
+        } else {
+          this.props.onDeselect?.(selected);
+        }
+
+        (this.props.onChange as (selected: SelectItem<T>[], event?: Event) => void)(
+            this.state.selected as SelectItem<T>[],
+            event
+        );
+
         if (tryKeepOpen) {
           this._redrawPopup();
         }


### PR DESCRIPTION
The `setState` updater function should be pure:

1. [https://react.dev/reference/react/useState#setstate-caveats:~:text=In Strict Mode%2C React will call your updater function twice](https://react.dev/reference/react/useState#setstate-caveats:~:text=In%20Strict%20Mode%2C%20React%20will%20call%20your%20updater%20function%20twice)
2. https://react.dev/reference/react/useState#my-initializer-or-updater-function-runs-twice

In Strict Mode it is called twice in the development mode.

Side effects:

1. https://github.com/JetBrains/ring-ui/blob/c1353fd060e51092921f8607024851f8ca5c31c2/src/select/select.tsx#L980
2. https://github.com/JetBrains/ring-ui/blob/c1353fd060e51092921f8607024851f8ca5c31c2/src/select/select.tsx#L983
4. https://github.com/JetBrains/ring-ui/blob/c1353fd060e51092921f8607024851f8ca5c31c2/src/select/select.tsx#L986