### PR TITLE
JT-83359 Enable back controlling shortcuts 

### DIFF
--- a/src/shortcuts/core.ts
+++ b/src/shortcuts/core.ts
@@ -218,9 +218,11 @@ class Shortcuts {
       !(element instanceof HTMLElement) ||
       key == null ||
       element.matches(this.ALLOW_SHORTCUTS_SELECTOR) ||
-      (element.dataset.enabledShortcuts != null
-        ? element.dataset.enabledShortcuts.split(',').includes(key)
-        : element.closest(this.ALLOW_SHORTCUTS_SELECTOR) != null)
+      element.closest(this.ALLOW_SHORTCUTS_SELECTOR) != null ||
+      (
+        element.dataset.enabledShortcuts != null &&
+        element.dataset.enabledShortcuts.split(',').includes(key)
+      )
     ) {
       return false;
     }


### PR DESCRIPTION
by having '.ring-js-shortcuts' on parent, removed in 473d55402947cfa2d98bcc2fe3a255c9f3f3ee29