### PR TITLE
Fix Storybook preview hooks can only be called inside decorators and story functions

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -47,5 +47,5 @@ export const parameters = {
 };
 
 export const decorators = [
-  themeDecorator(), stylesDecorator(), strictModeDecorator()
+  stylesDecorator(), strictModeDecorator(), themeDecorator()
 ];


### PR DESCRIPTION
![CleanShot 2024-09-20 at 16 43 15@2x](https://github.com/user-attachments/assets/5a678c29-d228-4a8c-a8dd-17fff286ee7b)
