### PR TITLE
chore(git): add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# This file is intended to ignore commits with bulk changes concerning formatting
+# Please consider adding full commit hashes here when performing similar operations
+# Requires git v2.23.0
+# To enable execute `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+
+# apply prettier suggestions
+4e172a0aa40cfe1e5725b83ffed099f5796cbe57

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "scripts": {
     "apply-resolutions": "npx npm-force-resolutions@0.0.10",
-    "postinstall": "husky",
+    "postinstall": "husky && npm run postinstall:gitconfig",
+    "postinstall:gitconfig": "git config blame.ignoreRevsFile .git-blame-ignore-revs",
     "prepare": "webpack -c .storybook/custom-header/webpack.config.js",
     "prea11y-audit": "playwright install",
     "a11y-audit": "test-storybook --url http://localhost:9999",


### PR DESCRIPTION
Small utility change: within the codebase there might be commits that one wants to ignore for `blame` such as recent `apply prettier suggestions`. See before 
<img width="760" alt="image" src="https://github.com/user-attachments/assets/b53b67fd-bc42-4919-9bfa-95150a798faa">
and after
<img width="639" alt="image" src="https://github.com/user-attachments/assets/fe64d6dd-5ca1-40d6-add7-a8aa74872b79">

