### PR TITLE
Drop index type from SelectionItem to make the typings more strict

### DIFF
--- a/src/data-list/data-list.test.tsx
+++ b/src/data-list/data-list.test.tsx
@@ -5,8 +5,12 @@ import {SelectionItem} from '../table/selection';
 import DataList, {DataListContainerProps} from './data-list';
 import Selection from './selection';
 
-const data: SelectionItem[] = [];
-const props: DataListContainerProps<SelectionItem> = {
+interface DateListTestItem extends SelectionItem {
+  selectable: boolean;
+}
+
+const data: DateListTestItem[] = [];
+const props: DataListContainerProps<DateListTestItem> = {
   data,
   selection: new Selection({data, isItemSelectable: item => Boolean(item.selectable)}),
   itemFormatter: () => ({}),

--- a/src/table/row.tsx
+++ b/src/table/row.tsx
@@ -210,7 +210,7 @@ export default class Row<T extends SelectionItem> extends PureComponent<RowProps
     const columns = typeof columnProps === 'function' ? columnProps(item) : columnProps;
 
     const cells = columns.map((column, index) => {
-      const getValue = column.getValue || (() => item[column.id] as ReactNode);
+      const getValue = column.getValue || (() => item[column.id as keyof T] as ReactNode);
       const getDataTest = column.getDataTest || (() => column.id);
       const value = getValue(item, column);
       const cellClasses = classNames({[style.cellRight]: column.rightAlign}, column.className);

--- a/src/table/selection.ts
+++ b/src/table/selection.ts
@@ -1,6 +1,5 @@
 export interface SelectionItem {
   id: string | number;
-  [key: string]: unknown; // TODO: Ring UI 7.0 drop this index type as it forces users to have index type in their data
 }
 
 export interface TableSelectionConfig<T extends SelectionItem> {

--- a/src/table/simple-table.stories.tsx
+++ b/src/table/simple-table.stories.tsx
@@ -78,7 +78,7 @@ Basic.storyName = 'basic';
 export const WithSorting: StoryFn<BasicDemoProps> = args => {
   const {onSort, onSelect, withCaption, onReorder, ...restProps} = args;
   const [data, setData] = useState<Item[]>([]);
-  const [sortKey, setSortKey] = useState<string>('country');
+  const [sortKey, setSortKey] = useState<keyof Item>('country');
   const [sortOrder, setSortOrder] = useState<boolean>(true);
 
   const isItemSelectable = useCallback((item: Item) => item.id !== 14, []);
@@ -93,7 +93,7 @@ export const WithSorting: StoryFn<BasicDemoProps> = args => {
   const handleSort = useCallback(
     (event: SortParams) => {
       onSort?.(event);
-      setSortKey(event.column.id);
+      setSortKey(event.column.id as keyof Item);
       setSortOrder(event.order);
     },
     [onSort],

--- a/src/table/table.stories.tsx
+++ b/src/table/table.stories.tsx
@@ -43,7 +43,7 @@ export const Basic: StoryFn<BasicDemoProps> = args => {
   const {onSort, onSelect, withCaption, onReorder, ...restProps} = args;
   const [data, setData] = useState<Item[]>([]);
   const [selection, setSelection] = useState<Selection<Item>>(new Selection());
-  const [sortKey, setSortKey] = useState<string>('country');
+  const [sortKey, setSortKey] = useState<keyof Item>('country');
   const [sortOrder, setSortOrder] = useState<boolean>(true);
   const [page, setPage] = useState<number>(1);
 
@@ -63,7 +63,7 @@ export const Basic: StoryFn<BasicDemoProps> = args => {
   const handleSort = useCallback(
     (event: SortParams) => {
       onSort?.(event);
-      setSortKey(event.column.id);
+      setSortKey(event.column.id as keyof Item);
       setSortOrder(event.order);
     },
     [onSort],


### PR DESCRIPTION
For example, this is what we have to do to extend `SelectionItem` without this fix:

```ts
export interface CustomAppInTableSelection extends CustomAppLite {
  // hack for TableSelection type mismatching
  [k: string]: unknown;
}

...

selection: TableSelection<CustomAppInTableSelection>;
```