### PR TITLE
Reduce usage of postcss-modules-values-replace `@value` syntax for future plugin removal

### DIFF
--- a/src/alert/alert.css
+++ b/src/alert/alert.css
@@ -1,9 +1,9 @@
 @import "../global/variables.css";
 
-@value animation-duration: 300ms;
-@value animation-easing: ease-out;
-
 .alert {
+  --ring-alert-animation-duration: 300ms;
+  --ring-alert-animation-easing: ease-out;
+
   position: relative;
 
   display: flex;
@@ -15,9 +15,9 @@
   padding: 0 calc(var(--ring-unit) * 2);
 
   transition:
-    transform animation-duration animation-easing,
-    margin-bottom animation-duration animation-easing,
-    opacity animation-duration animation-easing;
+    transform var(--ring-alert-animation-duration) var(--ring-alert-animation-easing),
+    margin-bottom var(--ring-alert-animation-duration) var(--ring-alert-animation-easing),
+    opacity var(--ring-alert-animation-duration) var(--ring-alert-animation-easing);
   white-space: nowrap;
   pointer-events: auto;
 
@@ -124,7 +124,7 @@
 
 .animationOpen {
   animation-name: show;
-  animation-duration: animation-duration;
+  animation-duration: var(--ring-alert-animation-duration);
 }
 
 .animationClosing {

--- a/src/button-group/button-group.css
+++ b/src/button-group/button-group.css
@@ -1,6 +1,6 @@
 @import "../global/variables.css";
 
-@value button, active, primary, button-shadow from "../button/button.css";
+@value button, active, primary from "../button/button.css";
 
 :root {
   --ring-button-group-default-z-index: 1;
@@ -22,7 +22,7 @@
 
   border-radius: var(--ring-border-radius);
 
-  box-shadow: button-shadow var(--ring-borders-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-borders-color);
 
   line-height: normal;
 }
@@ -115,30 +115,30 @@
 .buttonGroup .button.button:hover:not(:disabled),
 .buttonGroup .button.button:active:not(:disabled) {
   border-radius: var(--ring-border-radius);
-  box-shadow: button-shadow var(--ring-border-hover-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-border-hover-color);
 }
 
 .buttonGroup .button.button:focus-visible {
   border-radius: var(--ring-border-radius);
   box-shadow:
-    button-shadow var(--ring-border-hover-color),
+    var(--ring-button-shadow) var(--ring-border-hover-color),
     0 0 0 1px var(--ring-border-hover-color);
 }
 
 .buttonGroup .button.button.active {
   border-radius: var(--ring-border-radius);
-  box-shadow: button-shadow var(--ring-main-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-main-color);
 }
 
 .buttonGroup .button:focus-visible.active {
   border-radius: var(--ring-border-radius);
   box-shadow:
-    button-shadow var(--ring-main-color),
+    var(--ring-button-shadow) var(--ring-main-color),
     0 0 0 1px var(--ring-border-hover-color);
 }
 
 .buttonGroup .button.active[disabled] {
-  box-shadow: button-shadow var(--ring-border-selected-disabled-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-border-selected-disabled-color);
 }
 /* stylelint-enable */
 

--- a/src/button/button.css
+++ b/src/button/button.css
@@ -1,7 +1,10 @@
 @import "../global/variables.css";
 
-@value button-shadow: inset 0 0 0 1px;
-@value loaderWidth: calc(var(--ring-unit) * 8);
+:root {
+  --ring-button-focus-border-color: var(--ring-border-hover-color);
+  --ring-button-shadow: inset 0 0 0 1px;
+  --ring-button-loader-width: calc(var(--ring-unit) * 8);
+}
 
 .heightS {
   --ring-button-height: calc(var(--ring-unit) * 3);
@@ -28,8 +31,6 @@
 }
 
 .button {
-  --ring-button-focus-border-color: var(--ring-border-hover-color);
-
   box-sizing: border-box;
   margin: 0;
 
@@ -74,7 +75,7 @@
   color: var(--ring-text-color);
 
   background-color: var(--ring-button-background-color);
-  box-shadow: button-shadow var(--ring-button-border-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-button-border-color);
 
   font-size: var(--ring-button-font-size);
   line-height: var(--ring-button-line-height);
@@ -90,7 +91,7 @@
 
   &:focus-visible {
     box-shadow:
-      button-shadow var(--ring-button-focus-border-color),
+      var(--ring-button-shadow) var(--ring-button-focus-border-color),
       0 0 0 1px var(--ring-button-focus-border-color);
   }
 }
@@ -311,7 +312,7 @@
   &::before {
     display: block;
 
-    width: calc(100% + loaderWidth);
+    width: calc(100% + var(--ring-button-loader-width));
     height: 100%;
 
     content: "";
@@ -325,7 +326,7 @@
     );
 
     background-repeat: repeat;
-    background-size: loaderWidth;
+    background-size: var(--ring-button-loader-width);
   }
 }
 

--- a/src/checkbox/checkbox.css
+++ b/src/checkbox/checkbox.css
@@ -1,8 +1,8 @@
 @import "../global/variables.css";
 
-@value checkboxSize: 14px;
-
 .checkbox {
+  --ring-checkbox-size: 14px;
+
   position: relative;
 
   display: inline-flex;
@@ -27,8 +27,8 @@
   display: inline-block;
 
   box-sizing: border-box;
-  width: checkboxSize;
-  height: checkboxSize;
+  width: var(--ring-checkbox-size);
+  height: var(--ring-checkbox-size);
 
   user-select: none;
   transition:

--- a/src/content-layout/content-layout.css
+++ b/src/content-layout/content-layout.css
@@ -1,9 +1,10 @@
 @import "../global/variables.css";
 
 @value extra-small-screen-media, small-screen-media from "../global/global.css";
-@value sidebarWidth: calc(var(--ring-unit) * 30);
 
 .contentLayout {
+  --ring-content-layout-sidebar-width: calc(var(--ring-unit) * 30);
+
   position: relative;
 
   display: flex;
@@ -19,8 +20,8 @@
 }
 
 .sidebarContainer {
-  min-width: sidebarWidth;
-  max-width: sidebarWidth;
+  min-width: var(--ring-content-layout-sidebar-width);
+  max-width: var(--ring-content-layout-sidebar-width);
 }
 
 .sidebarContainerRight {
@@ -31,8 +32,8 @@
   overflow: auto;
 
   box-sizing: border-box;
-  min-width: sidebarWidth;
-  max-width: sidebarWidth;
+  min-width: var(--ring-content-layout-sidebar-width);
+  max-width: var(--ring-content-layout-sidebar-width);
   height: 100%;
   padding-right: calc(var(--ring-unit) * 2);
   padding-left: calc(var(--ring-unit) * 4);

--- a/src/data-list/data-list.css
+++ b/src/data-list/data-list.css
@@ -1,8 +1,8 @@
 @import "../global/variables.css";
 
-@value height, compensate from "../table/table.css";
-
 .dataListWrapper {
+  --ring-table-compensate: 2px;
+
   position: relative;
 }
 
@@ -25,7 +25,7 @@
 
   box-sizing: content-box;
   height: calc(4 * var(--ring-unit));
-  padding: 0 calc(var(--ring-unit) * 5) compensate 0;
+  padding: 0 calc(var(--ring-unit) * 5) var(--ring-table-compensate) 0;
 
   outline: none;
 

--- a/src/date-picker/date-picker.css
+++ b/src/date-picker/date-picker.css
@@ -4,12 +4,6 @@
 /* ensure styles order */
 @import "../input/input.css";
 
-@value cellSize: calc(var(--ring-unit) * 3);
-@value calHeight: calc(var(--ring-unit) * 36);
-@value calWidth: calc(var(--ring-unit) * 37);
-@value yearHeight: calc(var(--ring-unit) * 4);
-@value yearWidth: calc(var(--ring-unit) * 6);
-
 :root {
   /* stylelint-disable-next-line color-no-hex */
   --ring-date-picker-hover-color: var(--ring-border-hover-color);
@@ -88,6 +82,12 @@
 }
 
 .datePopup {
+  --ring-date-picker-cell-size: calc(var(--ring-unit) * 3);
+  --ring-date-picker-cal-height: calc(var(--ring-unit) * 36);
+  --ring-date-picker-cal-width: calc(var(--ring-unit) * 37);
+  --ring-date-picker-year-height: calc(var(--ring-unit) * 4);
+  --ring-date-picker-year-width: calc(var(--ring-unit) * 6);
+
   width: min-content;
 
   user-select: none;
@@ -201,7 +201,7 @@
 .weekday.weekday {
   display: inline-block;
 
-  width: cellSize;
+  width: var(--ring-date-picker-cell-size);
 
   text-align: center;
   text-transform: capitalize;
@@ -216,8 +216,8 @@
 
   overflow: hidden;
 
-  width: calWidth;
-  height: calHeight;
+  width: var(--ring-date-picker-cal-width);
+  height: var(--ring-date-picker-cal-height);
 
   box-shadow: 0 -1px var(--ring-line-color);
 }
@@ -225,7 +225,7 @@
 .months.months {
   position: absolute;
   top: 0;
-  right: yearWidth;
+  right: var(--ring-date-picker-year-width);
   bottom: 0;
   left: 0;
 }
@@ -246,9 +246,9 @@
 .month.month > * {
   flex-shrink: 0;
 
-  height: cellSize;
+  height: var(--ring-date-picker-cell-size);
 
-  line-height: cellSize;
+  line-height: var(--ring-date-picker-cell-size);
 }
 
 .monthTitle {
@@ -278,7 +278,7 @@
 .day.day {
   position: relative;
 
-  flex-basis: cellSize;
+  flex-basis: var(--ring-date-picker-cell-size);
 
   margin: 0;
 
@@ -516,12 +516,12 @@
 
   width: 100%;
 
-  height: cellSize;
+  height: var(--ring-date-picker-cell-size);
   padding-left: calc(var(--ring-unit) * 1.5);
 
   text-transform: capitalize;
 
-  line-height: cellSize;
+  line-height: var(--ring-date-picker-cell-size);
 }
 
 .monthSlider {
@@ -568,7 +568,7 @@
   top: 0;
   right: 0;
 
-  width: yearWidth;
+  width: var(--ring-date-picker-year-width);
 
   background-color: var(--ring-content-background-color);
   box-shadow: -1px 0 var(--ring-line-color);
@@ -586,13 +586,13 @@
 
   width: 100%;
 
-  height: yearHeight;
+  height: var(--ring-date-picker-year-height);
 
   text-align: center;
 
   color: var(--ring-secondary-color);
 
-  line-height: yearHeight;
+  line-height: var(--ring-date-picker-year-height);
 }
 
 .currentYear.currentYear {

--- a/src/global/global.css
+++ b/src/global/global.css
@@ -86,9 +86,6 @@
   }
 }
 
-/* Note: footer also has top margin which isn't taken into account here */
-@value footer-height: calc(var(--ring-unit) * 8);
-
 /* Media breakpoints (minimal values) */
 @value breakpoint-small: 640px;
 @value breakpoint-middle: 960px;

--- a/src/grid/grid.css
+++ b/src/grid/grid.css
@@ -2,35 +2,36 @@
 
 @value breakpoint-small, breakpoint-middle, breakpoint-large  from "../global/global.css";
 @value large-screen-media, middle-screen-media, small-screen-media from "../global/global.css";
-@value gutterWidth: (var(--ring-unit) * 2);
-@value gutterCompensation: calc(gutterWidth / -2);
-@value outerMargin: calc(var(--ring-unit) * 2);
-@value containerSmall: calc(breakpoint-small + gutterWidth);
-@value containerMedium: calc(breakpoint-middle + gutterWidth);
-@value containerLarge: calc(breakpoint-large + gutterWidth);
-@value width-1: 8.3333%;
-@value width-2: 16.6667%;
-@value width-3: 25%;
-@value width-4: 33.3333%;
-@value width-5: 41.6667%;
-@value width-6: 50%;
-@value width-7: 58.3333%;
-@value width-8: 66.6667%;
-@value width-9: 75%;
-@value width-10: 83.3333%;
-@value width-11: 91.6667%;
-@value width-12: 100%;
 
 .container-fluid,
 .container {
+  --ring-grid-gutter-width: calc(var(--ring-unit) * 2);
+  --ring-grid-gutter-compensation: calc(var(--ring-grid-gutter-width) / -2);
+  --ring-grid-outer-margin: calc(var(--ring-unit) * 2);
+  --ring-grid-container-small: calc(breakpoint-small + var(--ring-grid-gutter-width));
+  --ring-grid-container-medium: calc(breakpoint-middle + var(--ring-grid-gutter-width));
+  --ring-grid-container-large: calc(breakpoint-large + var(--ring-grid-gutter-width));
+  --ring-grid-width-1: 8.3333%;
+  --ring-grid-width-2: 16.6667%;
+  --ring-grid-width-3: 25%;
+  --ring-grid-width-4: 33.3333%;
+  --ring-grid-width-5: 41.6667%;
+  --ring-grid-width-6: 50%;
+  --ring-grid-width-7: 58.3333%;
+  --ring-grid-width-8: 66.6667%;
+  --ring-grid-width-9: 75%;
+  --ring-grid-width-10: 83.3333%;
+  --ring-grid-width-11: 91.6667%;
+  --ring-grid-width-12: 100%;
+
   margin-right: auto;
   margin-left: auto;
 }
 
 .container-fluid {
   min-width: calc(var(--ring-unit) * 40);
-  padding-right: outerMargin;
-  padding-left: outerMargin;
+  padding-right: var(--ring-grid-outer-margin);
+  padding-left: var(--ring-grid-outer-margin);
 }
 
 .row {
@@ -39,8 +40,8 @@
   flex-flow: row wrap;
 
   box-sizing: border-box;
-  margin-right: gutterCompensation;
-  margin-left: gutterCompensation;
+  margin-right: var(--ring-grid-gutter-compensation);
+  margin-left: var(--ring-grid-gutter-compensation);
 }
 
 .row.reverse {
@@ -85,8 +86,8 @@
   flex: 0 0 auto;
 
   box-sizing: border-box;
-  padding-right: calc(gutterWidth / 2);
-  padding-left: calc(gutterWidth / 2);
+  padding-right: calc(var(--ring-grid-gutter-width) / 2);
+  padding-left: calc(var(--ring-grid-gutter-width) / 2);
 }
 
 .col-xs {
@@ -97,75 +98,75 @@
 }
 
 .col-xs-1 {
-  flex-basis: width-1;
+  flex-basis: var(--ring-grid-width-1);
 
-  max-width: width-1;
+  max-width: var(--ring-grid-width-1);
 }
 
 .col-xs-2 {
-  flex-basis: width-2;
+  flex-basis: var(--ring-grid-width-2);
 
-  max-width: width-2;
+  max-width: var(--ring-grid-width-2);
 }
 
 .col-xs-3 {
-  flex-basis: width-3;
+  flex-basis: var(--ring-grid-width-3);
 
-  max-width: width-3;
+  max-width: var(--ring-grid-width-3);
 }
 
 .col-xs-4 {
-  flex-basis: width-4;
+  flex-basis: var(--ring-grid-width-4);
 
-  max-width: width-4;
+  max-width: var(--ring-grid-width-4);
 }
 
 .col-xs-5 {
-  flex-basis: width-5;
+  flex-basis: var(--ring-grid-width-5);
 
-  max-width: width-5;
+  max-width: var(--ring-grid-width-5);
 }
 
 .col-xs-6 {
-  flex-basis: width-6;
+  flex-basis: var(--ring-grid-width-6);
 
-  max-width: width-6;
+  max-width: var(--ring-grid-width-6);
 }
 
 .col-xs-7 {
-  flex-basis: width-7;
+  flex-basis: var(--ring-grid-width-7);
 
-  max-width: width-7;
+  max-width: var(--ring-grid-width-7);
 }
 
 .col-xs-8 {
-  flex-basis: width-8;
+  flex-basis: var(--ring-grid-width-8);
 
-  max-width: width-8;
+  max-width: var(--ring-grid-width-8);
 }
 
 .col-xs-9 {
-  flex-basis: width-9;
+  flex-basis: var(--ring-grid-width-9);
 
-  max-width: width-9;
+  max-width: var(--ring-grid-width-9);
 }
 
 .col-xs-10 {
-  flex-basis: width-10;
+  flex-basis: var(--ring-grid-width-10);
 
-  max-width: width-10;
+  max-width: var(--ring-grid-width-10);
 }
 
 .col-xs-11 {
-  flex-basis: width-11;
+  flex-basis: var(--ring-grid-width-11);
 
-  max-width: width-11;
+  max-width: var(--ring-grid-width-11);
 }
 
 .col-xs-12 {
-  flex-basis: width-12;
+  flex-basis: var(--ring-grid-width-12);
 
-  max-width: width-12;
+  max-width: var(--ring-grid-width-12);
 }
 
 .col-xs-offset-0 {
@@ -173,47 +174,47 @@
 }
 
 .col-xs-offset-1 {
-  margin-left: width-1;
+  margin-left: var(--ring-grid-width-1);
 }
 
 .col-xs-offset-2 {
-  margin-left: width-2;
+  margin-left: var(--ring-grid-width-2);
 }
 
 .col-xs-offset-3 {
-  margin-left: width-3;
+  margin-left: var(--ring-grid-width-3);
 }
 
 .col-xs-offset-4 {
-  margin-left: width-4;
+  margin-left: var(--ring-grid-width-4);
 }
 
 .col-xs-offset-5 {
-  margin-left: width-5;
+  margin-left: var(--ring-grid-width-5);
 }
 
 .col-xs-offset-6 {
-  margin-left: width-6;
+  margin-left: var(--ring-grid-width-6);
 }
 
 .col-xs-offset-7 {
-  margin-left: width-7;
+  margin-left: var(--ring-grid-width-7);
 }
 
 .col-xs-offset-8 {
-  margin-left: width-8;
+  margin-left: var(--ring-grid-width-8);
 }
 
 .col-xs-offset-9 {
-  margin-left: width-9;
+  margin-left: var(--ring-grid-width-9);
 }
 
 .col-xs-offset-10 {
-  margin-left: width-10;
+  margin-left: var(--ring-grid-width-10);
 }
 
 .col-xs-offset-11 {
-  margin-left: width-11;
+  margin-left: var(--ring-grid-width-11);
 }
 
 .start-xs {
@@ -268,7 +269,7 @@
 
 @media small-screen-media {
   .container {
-    width: containerSmall;
+    width: var(--ring-grid-container-small);
   }
 
   .col-sm,
@@ -300,8 +301,8 @@
     flex: 0 0 auto;
 
     box-sizing: border-box;
-    padding-right: calc(gutterWidth / 2);
-    padding-left: calc(gutterWidth / 2);
+    padding-right: calc(var(--ring-grid-gutter-width) / 2);
+    padding-left: calc(var(--ring-grid-gutter-width) / 2);
   }
 
   .col-sm {
@@ -312,75 +313,75 @@
   }
 
   .col-sm-1 {
-    flex-basis: width-1;
+    flex-basis: var(--ring-grid-width-1);
 
-    max-width: width-1;
+    max-width: var(--ring-grid-width-1);
   }
 
   .col-sm-2 {
-    flex-basis: width-2;
+    flex-basis: var(--ring-grid-width-2);
 
-    max-width: width-2;
+    max-width: var(--ring-grid-width-2);
   }
 
   .col-sm-3 {
-    flex-basis: width-3;
+    flex-basis: var(--ring-grid-width-3);
 
-    max-width: width-3;
+    max-width: var(--ring-grid-width-3);
   }
 
   .col-sm-4 {
-    flex-basis: width-4;
+    flex-basis: var(--ring-grid-width-4);
 
-    max-width: width-4;
+    max-width: var(--ring-grid-width-4);
   }
 
   .col-sm-5 {
-    flex-basis: width-5;
+    flex-basis: var(--ring-grid-width-5);
 
-    max-width: width-5;
+    max-width: var(--ring-grid-width-5);
   }
 
   .col-sm-6 {
-    flex-basis: width-6;
+    flex-basis: var(--ring-grid-width-6);
 
-    max-width: width-6;
+    max-width: var(--ring-grid-width-6);
   }
 
   .col-sm-7 {
-    flex-basis: width-7;
+    flex-basis: var(--ring-grid-width-7);
 
-    max-width: width-7;
+    max-width: var(--ring-grid-width-7);
   }
 
   .col-sm-8 {
-    flex-basis: width-8;
+    flex-basis: var(--ring-grid-width-8);
 
-    max-width: width-8;
+    max-width: var(--ring-grid-width-8);
   }
 
   .col-sm-9 {
-    flex-basis: width-9;
+    flex-basis: var(--ring-grid-width-9);
 
-    max-width: width-9;
+    max-width: var(--ring-grid-width-9);
   }
 
   .col-sm-10 {
-    flex-basis: width-10;
+    flex-basis: var(--ring-grid-width-10);
 
-    max-width: width-10;
+    max-width: var(--ring-grid-width-10);
   }
 
   .col-sm-11 {
-    flex-basis: width-11;
+    flex-basis: var(--ring-grid-width-11);
 
-    max-width: width-11;
+    max-width: var(--ring-grid-width-11);
   }
 
   .col-sm-12 {
-    flex-basis: width-12;
+    flex-basis: var(--ring-grid-width-12);
 
-    max-width: width-12;
+    max-width: var(--ring-grid-width-12);
   }
 
   .col-sm-offset-0 {
@@ -388,47 +389,47 @@
   }
 
   .col-sm-offset-1 {
-    margin-left: width-1;
+    margin-left: var(--ring-grid-width-1);
   }
 
   .col-sm-offset-2 {
-    margin-left: width-2;
+    margin-left: var(--ring-grid-width-2);
   }
 
   .col-sm-offset-3 {
-    margin-left: width-3;
+    margin-left: var(--ring-grid-width-3);
   }
 
   .col-sm-offset-4 {
-    margin-left: width-4;
+    margin-left: var(--ring-grid-width-4);
   }
 
   .col-sm-offset-5 {
-    margin-left: width-5;
+    margin-left: var(--ring-grid-width-5);
   }
 
   .col-sm-offset-6 {
-    margin-left: width-6;
+    margin-left: var(--ring-grid-width-6);
   }
 
   .col-sm-offset-7 {
-    margin-left: width-7;
+    margin-left: var(--ring-grid-width-7);
   }
 
   .col-sm-offset-8 {
-    margin-left: width-8;
+    margin-left: var(--ring-grid-width-8);
   }
 
   .col-sm-offset-9 {
-    margin-left: width-9;
+    margin-left: var(--ring-grid-width-9);
   }
 
   .col-sm-offset-10 {
-    margin-left: width-10;
+    margin-left: var(--ring-grid-width-10);
   }
 
   .col-sm-offset-11 {
-    margin-left: width-11;
+    margin-left: var(--ring-grid-width-11);
   }
 
   .start-sm {
@@ -484,7 +485,7 @@
 
 @media middle-screen-media {
   .container {
-    width: containerMedium;
+    width: var(--ring-grid-container-medium);
   }
 
   .col-md,
@@ -516,8 +517,8 @@
     flex: 0 0 auto;
 
     box-sizing: border-box;
-    padding-right: calc(gutterWidth / 2);
-    padding-left: calc(gutterWidth / 2);
+    padding-right: calc(var(--ring-grid-gutter-width) / 2);
+    padding-left: calc(var(--ring-grid-gutter-width) / 2);
   }
 
   .col-md {
@@ -528,75 +529,75 @@
   }
 
   .col-md-1 {
-    flex-basis: width-1;
+    flex-basis: var(--ring-grid-width-1);
 
-    max-width: width-1;
+    max-width: var(--ring-grid-width-1);
   }
 
   .col-md-2 {
-    flex-basis: width-2;
+    flex-basis: var(--ring-grid-width-2);
 
-    max-width: width-2;
+    max-width: var(--ring-grid-width-2);
   }
 
   .col-md-3 {
-    flex-basis: width-3;
+    flex-basis: var(--ring-grid-width-3);
 
-    max-width: width-3;
+    max-width: var(--ring-grid-width-3);
   }
 
   .col-md-4 {
-    flex-basis: width-4;
+    flex-basis: var(--ring-grid-width-4);
 
-    max-width: width-4;
+    max-width: var(--ring-grid-width-4);
   }
 
   .col-md-5 {
-    flex-basis: width-5;
+    flex-basis: var(--ring-grid-width-5);
 
-    max-width: width-5;
+    max-width: var(--ring-grid-width-5);
   }
 
   .col-md-6 {
-    flex-basis: width-6;
+    flex-basis: var(--ring-grid-width-6);
 
-    max-width: width-6;
+    max-width: var(--ring-grid-width-6);
   }
 
   .col-md-7 {
-    flex-basis: width-7;
+    flex-basis: var(--ring-grid-width-7);
 
-    max-width: width-7;
+    max-width: var(--ring-grid-width-7);
   }
 
   .col-md-8 {
-    flex-basis: width-8;
+    flex-basis: var(--ring-grid-width-8);
 
-    max-width: width-8;
+    max-width: var(--ring-grid-width-8);
   }
 
   .col-md-9 {
-    flex-basis: width-9;
+    flex-basis: var(--ring-grid-width-9);
 
-    max-width: width-9;
+    max-width: var(--ring-grid-width-9);
   }
 
   .col-md-10 {
-    flex-basis: width-10;
+    flex-basis: var(--ring-grid-width-10);
 
-    max-width: width-10;
+    max-width: var(--ring-grid-width-10);
   }
 
   .col-md-11 {
-    flex-basis: width-11;
+    flex-basis: var(--ring-grid-width-11);
 
-    max-width: width-11;
+    max-width: var(--ring-grid-width-11);
   }
 
   .col-md-12 {
-    flex-basis: width-12;
+    flex-basis: var(--ring-grid-width-12);
 
-    max-width: width-12;
+    max-width: var(--ring-grid-width-12);
   }
 
   .col-md-offset-0 {
@@ -604,47 +605,47 @@
   }
 
   .col-md-offset-1 {
-    margin-left: width-1;
+    margin-left: var(--ring-grid-width-1);
   }
 
   .col-md-offset-2 {
-    margin-left: width-2;
+    margin-left: var(--ring-grid-width-2);
   }
 
   .col-md-offset-3 {
-    margin-left: width-3;
+    margin-left: var(--ring-grid-width-3);
   }
 
   .col-md-offset-4 {
-    margin-left: width-4;
+    margin-left: var(--ring-grid-width-4);
   }
 
   .col-md-offset-5 {
-    margin-left: width-5;
+    margin-left: var(--ring-grid-width-5);
   }
 
   .col-md-offset-6 {
-    margin-left: width-6;
+    margin-left: var(--ring-grid-width-6);
   }
 
   .col-md-offset-7 {
-    margin-left: width-7;
+    margin-left: var(--ring-grid-width-7);
   }
 
   .col-md-offset-8 {
-    margin-left: width-8;
+    margin-left: var(--ring-grid-width-8);
   }
 
   .col-md-offset-9 {
-    margin-left: width-9;
+    margin-left: var(--ring-grid-width-9);
   }
 
   .col-md-offset-10 {
-    margin-left: width-10;
+    margin-left: var(--ring-grid-width-10);
   }
 
   .col-md-offset-11 {
-    margin-left: width-11;
+    margin-left: var(--ring-grid-width-11);
   }
 
   .start-md {
@@ -700,7 +701,7 @@
 
 @media large-screen-media {
   .container {
-    width: containerLarge;
+    width: var(--ring-grid-container-large);
   }
 
   .col-lg,
@@ -732,8 +733,8 @@
     flex: 0 0 auto;
 
     box-sizing: border-box;
-    padding-right: calc(gutterWidth / 2);
-    padding-left: calc(gutterWidth / 2);
+    padding-right: calc(var(--ring-grid-gutter-width) / 2);
+    padding-left: calc(var(--ring-grid-gutter-width) / 2);
   }
 
   .col-lg {
@@ -744,75 +745,75 @@
   }
 
   .col-lg-1 {
-    flex-basis: width-1;
+    flex-basis: var(--ring-grid-width-1);
 
-    max-width: width-1;
+    max-width: var(--ring-grid-width-1);
   }
 
   .col-lg-2 {
-    flex-basis: width-2;
+    flex-basis: var(--ring-grid-width-2);
 
-    max-width: width-2;
+    max-width: var(--ring-grid-width-2);
   }
 
   .col-lg-3 {
-    flex-basis: width-3;
+    flex-basis: var(--ring-grid-width-3);
 
-    max-width: width-3;
+    max-width: var(--ring-grid-width-3);
   }
 
   .col-lg-4 {
-    flex-basis: width-4;
+    flex-basis: var(--ring-grid-width-4);
 
-    max-width: width-4;
+    max-width: var(--ring-grid-width-4);
   }
 
   .col-lg-5 {
-    flex-basis: width-5;
+    flex-basis: var(--ring-grid-width-5);;
 
-    max-width: width-5;
+    max-width: var(--ring-grid-width-5);
   }
 
   .col-lg-6 {
-    flex-basis: width-6;
+    flex-basis: var(--ring-grid-width-6);
 
-    max-width: width-6;
+    max-width: var(--ring-grid-width-6);
   }
 
   .col-lg-7 {
-    flex-basis: width-7;
+    flex-basis: var(--ring-grid-width-7);
 
-    max-width: width-7;
+    max-width: var(--ring-grid-width-7);
   }
 
   .col-lg-8 {
-    flex-basis: width-8;
+    flex-basis: var(--ring-grid-width-8);
 
-    max-width: width-8;
+    max-width: var(--ring-grid-width-8);
   }
 
   .col-lg-9 {
-    flex-basis: width-9;
+    flex-basis: var(--ring-grid-width-9);
 
-    max-width: width-9;
+    max-width: var(--ring-grid-width-9);
   }
 
   .col-lg-10 {
-    flex-basis: width-10;
+    flex-basis: var(--ring-grid-width-10);
 
-    max-width: width-10;
+    max-width: var(--ring-grid-width-10);
   }
 
   .col-lg-11 {
-    flex-basis: width-11;
+    flex-basis: var(--ring-grid-width-11);
 
-    max-width: width-11;
+    max-width: var(--ring-grid-width-11);
   }
 
   .col-lg-12 {
-    flex-basis: width-12;
+    flex-basis: var(--ring-grid-width-12);
 
-    max-width: width-12;
+    max-width: var(--ring-grid-width-12);
   }
 
   .col-lg-offset-0 {
@@ -820,47 +821,47 @@
   }
 
   .col-lg-offset-1 {
-    margin-left: width-1;
+    margin-left: var(--ring-grid-width-1);
   }
 
   .col-lg-offset-2 {
-    margin-left: width-2;
+    margin-left: var(--ring-grid-width-2);
   }
 
   .col-lg-offset-3 {
-    margin-left: width-3;
+    margin-left: var(--ring-grid-width-3);
   }
 
   .col-lg-offset-4 {
-    margin-left: width-4;
+    margin-left: var(--ring-grid-width-4);
   }
 
   .col-lg-offset-5 {
-    margin-left: width-5;
+    margin-left: var(--ring-grid-width-5);
   }
 
   .col-lg-offset-6 {
-    margin-left: width-6;
+    margin-left: var(--ring-grid-width-6);
   }
 
   .col-lg-offset-7 {
-    margin-left: width-7;
+    margin-left: var(--ring-grid-width-7);
   }
 
   .col-lg-offset-8 {
-    margin-left: width-8;
+    margin-left: var(--ring-grid-width-8);
   }
 
   .col-lg-offset-9 {
-    margin-left: width-9;
+    margin-left: var(--ring-grid-width-9);
   }
 
   .col-lg-offset-10 {
-    margin-left: width-10;
+    margin-left: var(--ring-grid-width-10);
   }
 
   .col-lg-offset-11 {
-    margin-left: width-11;
+    margin-left: var(--ring-grid-width-11);
   }
 
   .start-lg {

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -1,20 +1,19 @@
 @import "../global/variables.css";
 
-@value dark from "../global/variables_dark.css";
 @value link, active from "../link/link.css";
-@value compensate: 3px;
-@value compensated: calc(calc(var(--ring-unit) * 8) - compensate);
 
 :root {
   --ring-header-link-color: var(--ring-link-color);
 }
 
-.dark,
 :global(.ring-ui-theme-dark) {
   --ring-header-link-color: var(--ring-text-color);
 }
 
 .header {
+  --ring-header-compensate: 3px;
+  --ring-header-compensated: calc(calc(var(--ring-unit) * 8) - var(--ring-header-compensate));
+
   display: flex;
   overflow: hidden;
   align-items: center;
@@ -26,14 +25,14 @@
 
   background-color: var(--ring-navigation-background-color);
 
-  line-height: compensated;
+  line-height: var(--ring-header-compensated);
 
   & > * {
     display: inline-block;
 
     box-sizing: border-box;
     height: calc(var(--ring-unit) * 8);
-    padding: 0 calc(var(--ring-unit) * 1.5) compensate;
+    padding: 0 calc(var(--ring-unit) * 1.5) var(--ring-header-compensate);
   }
 
   /* override link */
@@ -77,7 +76,6 @@
   }
 }
 
-html.dark .headerVertical,
 html:global(.ring-ui-theme-dark) .headerVertical {
   box-shadow: inset -1px 0 var(--ring-line-color);
 }
@@ -114,7 +112,7 @@ html:global(.ring-ui-theme-dark) .headerVertical {
   align-items: flex-end;
 
   margin-left: auto;
-  padding: 0 0 compensate;
+  padding: 0 0 var(--ring-header-compensate);
 }
 
 /* override .header > * */
@@ -132,7 +130,7 @@ html:global(.ring-ui-theme-dark) .headerVertical {
 }
 
 .trayItemContent {
-  height: compensated;
+  height: var(--ring-header-compensated);
 }
 
 .icon {
@@ -148,11 +146,11 @@ html:global(.ring-ui-theme-dark) .headerVertical {
 
 /* override button */
 .icon.icon {
-  height: compensated;
+  height: var(--ring-header-compensated);
 
   padding-top: calc(var(--ring-unit) / 2);
 
-  line-height: compensated;
+  line-height: var(--ring-header-compensated);
 }
 
 .headerVertical .icon {
@@ -182,7 +180,7 @@ html:global(.ring-ui-theme-dark) .headerVertical {
   align-items: center;
 
   width: auto;
-  height: compensated;
+  height: var(--ring-header-compensated);
   padding-left: var(--ring-unit);
 
   vertical-align: bottom;
@@ -196,7 +194,7 @@ html:global(.ring-ui-theme-dark) .headerVertical {
 .profile {
   composes: profileEmpty;
 
-  height: compensated;
+  height: var(--ring-header-compensated);
 
   cursor: pointer;
 }

--- a/src/island/island.css
+++ b/src/island/island.css
@@ -1,9 +1,9 @@
 @import "../global/variables.css";
 
-@value gradientStart: rgba(255, 255, 255, 0);
-@value gradientStop: var(--ring-content-background-color);
-
 .island {
+  --ring-island-gradient-start: rgba(255, 255, 255, 0);
+  --ring-island-gradient-stop: var(--ring-content-background-color);
+
   display: flex;
   flex-direction: column;
 
@@ -103,7 +103,7 @@
 
   opacity: 0.8;
 
-  background: linear-gradient(to top, gradientStart, gradientStop);
+  background: linear-gradient(to top, var(--ring-island-gradient-start), var(--ring-island-gradient-stop));
 }
 
 .contentWithTopFade:first-child::before {
@@ -127,5 +127,5 @@
   opacity: 0.8;
   border-bottom-right-radius: var(--ring-border-radius);
   border-bottom-left-radius: var(--ring-border-radius);
-  background: linear-gradient(to bottom, gradientStart, gradientStop);
+  background: linear-gradient(to bottom, var(--ring-island-gradient-start), var(--ring-island-gradient-stop));
 }

--- a/src/loader-inline/loader-inline.css
+++ b/src/loader-inline/loader-inline.css
@@ -1,13 +1,10 @@
 @import "../global/variables.css";
 
-@value dark from "../global/variables_dark.css";
-
 :root {
   /* stylelint-disable-next-line color-no-hex */
   --ring-loader-inline-stops: #ff00eb, #bd3bff, #008eff, #58ba00, #f48700, #ff00eb;
 }
 
-.dark,
 :global(.ring-ui-theme-dark) {
   /* stylelint-disable-next-line color-no-hex */
   --ring-loader-inline-stops: #ff2eef, #d178ff, #289fff, #88d444, #ffe000, #ff2eef;

--- a/src/markdown/markdown.css
+++ b/src/markdown/markdown.css
@@ -1,7 +1,5 @@
 @import "../global/variables.css";
 
-@value p-margin: 10px;
-
 .inline {
   &,
   & p {
@@ -10,6 +8,8 @@
 }
 
 .markdown {
+  --ring-markdown-p-margin: 10px;
+
   composes: font from "../global/global.css";
 
   & ol,
@@ -23,12 +23,12 @@
     margin: 0;
 
     &:not(:first-child) {
-      margin-top: p-margin;
+      margin-top: var(--ring-markdown-p-margin);
     }
   }
 
   & li {
-    margin-top: p-margin;
+    margin-top: var(--ring-markdown-p-margin);
   }
 
   & li {
@@ -42,7 +42,7 @@
   }
 
   & hr {
-    margin: p-margin 0;
+    margin: var(--ring-markdown-p-margin) 0;
 
     border: none;
     border-bottom: 1px solid var(--ring-line-color);

--- a/src/progress-bar/progress-bar.css
+++ b/src/progress-bar/progress-bar.css
@@ -1,13 +1,10 @@
 @import "../global/variables.css";
 
-@value dark from "../global/variables_dark.css";
-
 :root {
   --ring-progress-bar-background-color: rgba(0, 0, 0, 0.2);
   --ring-progress-bar-line-background-color: rgba(255, 255, 255, 0.6);
 }
 
-.dark,
 :global(.ring-ui-theme-dark) {
   --ring-progress-bar-background-color: rgba(255, 255, 255, 0.3);
   --ring-progress-bar-line-background-color: rgba(255, 255, 255, 0.4);

--- a/src/query-assist/query-assist.css
+++ b/src/query-assist/query-assist.css
@@ -1,9 +1,6 @@
 @import "../global/variables.css";
 @import "../button/button.css";
 
-@value overInputZIndex: 2;
-@value inputGap: calc(var(--ring-unit) * 3);
-
 .queryAssist {
   --ring-input-icon-offset: calc(var(--ring-unit) * 2.5);
   --ring-input-padding-inline: var(--ring-unit);

--- a/src/select/select.css
+++ b/src/select/select.css
@@ -1,7 +1,5 @@
 @import "../global/variables.css";
 
-@value button-shadow from "../button/button.css";
-
 .select {
   position: relative;
 
@@ -174,11 +172,11 @@
 }
 
 .buttonValue:focus-visible {
-  box-shadow: button-shadow var(--ring-main-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-main-color);
 }
 
 .buttonValueOpen.buttonValueOpen {
-  box-shadow: button-shadow var(--ring-main-color);
+  box-shadow: var(--ring-button-shadow) var(--ring-main-color);
 }
 
 .buttonValueEmpty.buttonValueEmpty {

--- a/src/slider/slider.css
+++ b/src/slider/slider.css
@@ -1,5 +1,3 @@
-@value dark from "../global/variables_dark.css";
-
 .slider {
   --ring-slider-thumb-color: var(--ring-content-background-color);
   --ring-slider-thumb-border: var(--ring-main-color);
@@ -22,7 +20,6 @@
   }
 }
 
-.dark,
 :global(.ring-ui-theme-dark) {
   .slider {
     --ring-slider-thumb-color: var(--ring-main-color);

--- a/src/table/table.css
+++ b/src/table/table.css
@@ -1,9 +1,10 @@
 @import "../global/variables.css";
 
-@value compensate: 2px;
-@value compensated: calc(calc(4 * var(--ring-unit)) - compensate);
-
 .tableWrapper {
+  --ring-table-compensate: 2px;
+  --ring-table-compensated:  calc(calc(4 * var(--ring-unit)) - var(--ring-table-compensate));
+  --ring-table-top: -3px;
+
   position: relative;
 }
 
@@ -109,7 +110,7 @@
 .row {
   outline: none;
 
-  line-height: compensated;
+  line-height: var(--ring-table-compensated);
 }
 
 /* stylelint-disable-next-line selector-max-specificity */
@@ -194,17 +195,15 @@
   float: left;
 
   height: 16px;
-  padding-right: compensate;
+  padding-right: var(--ring-table-compensate);
 }
 
 .metaColumn.headerMetaColumn {
   padding-top: 1px;
 }
 
-@value top: -3px;
-
 .dragHandle {
-  top: top;
+  top: var(--ring-table-top);
   left: calc(-2 * var(--ring-unit));
 
   cursor: grab;
@@ -216,7 +215,7 @@
 .dragHandle.dragHandle {
   position: absolute;
 
-  height: calc(calc(4 * var(--ring-unit)) - top);
+  height: calc(calc(4 * var(--ring-unit)) - var(--ring-table-top));
   padding: 0;
 }
 

--- a/src/tabs/tabs.css
+++ b/src/tabs/tabs.css
@@ -3,20 +3,18 @@
 /* ensure styles order */
 @import "../link/link.css";
 
-@value dark from "../global/variables_dark.css";
-@value line-shadow: inset 0 -1px 0 0;
-@value selected-line-shadow: inset 0 -2px 0 0;
-
 :root {
   --ring-selected-tab-color: var(--ring-text-color);
 }
 
-.dark,
 :global(.ring-ui-theme-dark) {
   --ring-selected-tab-color: var(--ring-text-color);
 }
 
 .tabs {
+  --ring-tabs-line-shadow: inset 0 -1px 0 0;
+  --ring-tabs-selected-line-shadow: inset 0 -2px 0 0;
+
   composes: font from "../global/global.css";
 }
 
@@ -31,7 +29,7 @@
 }
 
 .titles {
-  box-shadow: line-shadow var(--ring-line-color);
+  box-shadow: var(--ring-tabs-line-shadow) var(--ring-line-color);
 }
 
 .title {
@@ -62,13 +60,13 @@
     &.selected,
     &.collapsed {
       color: inherit;
-      box-shadow: selected-line-shadow var(--ring-text-color);
+      box-shadow: var(--ring-tabs-selected-line-shadow) var(--ring-text-color);
     }
   }
 
   &:focus-visible {
     color: var(--ring-main-color);
-    box-shadow: selected-line-shadow var(--ring-main-color);
+    box-shadow: var(--ring-tabs-selected-line-shadow) var(--ring-main-color);
   }
 
   &[disabled] {
@@ -91,7 +89,7 @@
   color: var(--ring-active-text-color);
 
   outline: none;
-  box-shadow: selected-line-shadow var(--ring-selected-tab-color);
+  box-shadow: var(--ring-tabs-selected-line-shadow) var(--ring-selected-tab-color);
 
   font-weight: var(--ring-font-weight-bold);
 }

--- a/src/tag/tag.css
+++ b/src/tag/tag.css
@@ -1,8 +1,8 @@
 @import "../global/variables.css";
 
-@value max-height: 20px;
-
 .tag {
+  --ring-tag-max-height: 20px;
+
   composes: resetButton from "../global/global.css";
 
   position: relative;
@@ -12,7 +12,7 @@
 
   box-sizing: border-box;
   max-width: 100%;
-  height: max-height;
+  height: var(--ring-tag-max-height);
 
   padding: 0 var(--ring-unit);
 
@@ -110,8 +110,8 @@
   overflow: hidden;
 
   box-sizing: border-box;
-  width: max-height;
-  height: max-height;
+  width: var(--ring-tag-max-height);
+  height: var(--ring-tag-max-height);
   margin-right: calc(var(--ring-unit) / 2);
   margin-left: calc(var(--ring-unit) * -1);
 
@@ -131,7 +131,7 @@
 }
 
 .avatarIcon {
-  width: max-height;
+  width: var(--ring-tag-max-height);
 
   margin-right: -4px;
 

--- a/src/toggle/toggle.css
+++ b/src/toggle/toggle.css
@@ -1,10 +1,10 @@
 @import "../global/variables.css";
 
-@value padding: 2px;
-@value duration: 300ms;
-@value timing-function: cubic-bezier(0.23, 1, 0.32, 1);
-
 .toggle {
+  --ring-toggle-padding: 2px;
+  --ring-toggle-duration: 300ms;
+  --ring-toggle-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+
   display: inline-flex;
   align-items: baseline;
 
@@ -70,7 +70,7 @@
   width: 100%;
   height: 100%;
 
-  transition: background-color timing-function duration;
+  transition: background-color var(--ring-toggle-timing-function) var(--ring-toggle-duration);
 
   border: solid 1px var(--ring-toggle-border-color);
 
@@ -94,9 +94,9 @@
 
     content: "";
 
-    transition: transform timing-function duration;
+    transition: transform var(--ring-toggle-timing-function) var(--ring-toggle-duration);
 
-    transform: translateX(padding) translateY(-50%);
+    transform: translateX(var(--ring-toggle-padding)) translateY(-50%);
 
     border: solid 1px var(--ring-switch-border-color);
 
@@ -134,7 +134,7 @@
 
   /* stylelint-disable-next-line selector-max-specificity */
   & .input:checked + ::before {
-    transform: translateX(calc(var(--ring-unit) * 1.5 - padding)) translateY(-50%);
+    transform: translateX(calc(var(--ring-unit) * 1.5 - var(--ring-toggle-padding))) translateY(-50%);
   }
 }
 
@@ -184,7 +184,7 @@
 
   /* stylelint-disable-next-line selector-max-specificity */
   & .input:checked + ::before {
-    transform: translateX(calc(var(--ring-unit) * 2 - padding)) translateY(-50%);
+    transform: translateX(calc(var(--ring-unit) * 2 - var(--ring-toggle-padding))) translateY(-50%);
   }
 }
 


### PR DESCRIPTION
I think it makes sense to reduce usage of non-standard CSS syntax to bare minimum

Therefore I replaced local usages of `@value` syntax with CSS Custom Properties

`@value` is still used to import hashed classNames from other CSS files, but this is covered by `postcss-modules-values` [plugin](https://github.com/madyankin/postcss-modules/blob/bd64c71ddfd81b615104b0727ce9a623da0eaef6/src/scoping.js#L6) and is a part of CSS Modules stack 