### PR TITLE
<Collapse /> component: Stop rendering the collapsed content.

### DIFF
--- a/packages/screenshots/testplane/chrome/components/collapse/expanded by default/expanded by default-dark.png
+++ b/packages/screenshots/testplane/chrome/components/collapse/expanded by default/expanded by default-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da553b0fa3c8f7080f8711223a2b57db4d4ed8042dc6d1d593718949989f3ddb
+size 14635

--- a/packages/screenshots/testplane/chrome/components/collapse/with controlled collapse state/with controlled collapse state-dark.png
+++ b/packages/screenshots/testplane/chrome/components/collapse/with controlled collapse state/with controlled collapse state-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0d38c000db31b17b958e10091aa52c5854f21864c84cb734e5e49e5d6e96992
+size 14466

--- a/packages/screenshots/testplane/firefox/components/collapse/expanded by default/expanded by default-dark.png
+++ b/packages/screenshots/testplane/firefox/components/collapse/expanded by default/expanded by default-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71c25f05ab0ff77b3355b974f49dbfcbd3928a2cfd6aa902c6cda99c528c210
+size 34316

--- a/packages/screenshots/testplane/firefox/components/collapse/with controlled collapse state/with controlled collapse state-dark.png
+++ b/packages/screenshots/testplane/firefox/components/collapse/with controlled collapse state/with controlled collapse state-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d659483c64ceba5a302f2c12c0dd0fb2c7f319951d8049f9fbce1fe3fd0c4868
+size 34085

--- a/src/collapse/collapse-content.tsx
+++ b/src/collapse/collapse-content.tsx
@@ -50,13 +50,10 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
     }
 
     const container = containerRef.current;
-    if (container) {
-      container.addEventListener('transitionend', onTransitionEnd);
-    }
+    container?.addEventListener('transitionend', onTransitionEnd);
+
     return () => {
-      if (container) {
-        container.removeEventListener('transitionend', onTransitionEnd);
-      }
+      container?.removeEventListener('transitionend', onTransitionEnd);
     };
   }, [collapsed]);
 

--- a/src/collapse/collapse.stories.tsx
+++ b/src/collapse/collapse.stories.tsx
@@ -164,3 +164,17 @@ export const WithDynamicContent = () => {
 };
 
 WithDynamicContent.storyName = 'With dynamic content';
+
+export const ExpandedByDefault = () => (
+  <div className={styles.container}>
+    <Collapse defaultExpanded>
+      <CollapseControl>
+        {(collapsed: boolean) => <Button>{collapsed ? 'Show more' : 'Show less'}</Button>}
+      </CollapseControl>
+      <CollapseContent>{text}</CollapseContent>
+    </Collapse>
+  </div>
+);
+
+ExpandedByDefault.storyName = 'Expanded by default';
+ExpandedByDefault.parameters = {screenshots: {actions: []}};

--- a/src/collapse/collapse.stories.tsx
+++ b/src/collapse/collapse.stories.tsx
@@ -167,7 +167,7 @@ WithDynamicContent.storyName = 'With dynamic content';
 
 export const ExpandedByDefault = () => (
   <div className={styles.container}>
-    <Collapse defaultExpanded>
+    <Collapse defaultCollapsed={false}>
       <CollapseControl>
         {(collapsed: boolean) => <Button>{collapsed ? 'Show more' : 'Show less'}</Button>}
       </CollapseControl>
@@ -178,3 +178,31 @@ export const ExpandedByDefault = () => (
 
 ExpandedByDefault.storyName = 'Expanded by default';
 ExpandedByDefault.parameters = {screenshots: {actions: []}};
+
+export const WithControlledCollapseState = () => {
+  const [collapsed, toggle] = useState(true);
+
+  const onClick = () => {
+    toggle(!collapsed);
+  };
+
+  return (
+    <>
+      <div className={styles.container}>
+        <Button data-test="trigger" onClick={onClick}>
+          {collapsed ? 'Show more' : 'Show less'}
+        </Button>
+      </div>
+      <div className={styles.container}>
+        <Collapse collapsed={collapsed}>
+          <CollapseContent>{text}</CollapseContent>
+        </Collapse>
+      </div>
+    </>
+  );
+};
+
+WithControlledCollapseState.storyName = 'With controlled collapse state';
+WithControlledCollapseState.parameters = {
+  screenshots: {actions: [{type: 'click', selector: '[data-test~=trigger]'}]},
+};

--- a/src/collapse/collapse.test.tsx
+++ b/src/collapse/collapse.test.tsx
@@ -30,10 +30,12 @@ const Dummy = ({
   minHeight,
   disableAnimation,
   controlAsFunc,
+  defaultExpanded = false,
 }: {
   minHeight: number;
   disableAnimation: boolean;
   controlAsFunc: boolean;
+  defaultExpanded: boolean;
 }) => {
   const [texts, setTexts] = useState([textMock]);
 
@@ -42,7 +44,7 @@ const Dummy = ({
       <button type="button" onClick={() => setTexts([...texts, textMock])}>
         {'More text'}
       </button>
-      <Collapse onChange={onChangeMock} disableAnimation={disableAnimation}>
+      <Collapse onChange={onChangeMock} disableAnimation={disableAnimation} defaultExpanded={defaultExpanded}>
         <CollapseControl>
           {controlAsFunc ? (
             <button type="button">{'Show text'}</button>
@@ -61,8 +63,15 @@ const Dummy = ({
   );
 };
 
-function renderComponent(minHeight = 0, disableAnimation = false, controlAsFunc = false) {
-  return render(<Dummy minHeight={minHeight} disableAnimation={disableAnimation} controlAsFunc={controlAsFunc} />);
+function renderComponent(minHeight = 0, disableAnimation = false, controlAsFunc = false, defaultExpanded = false) {
+  return render(
+    <Dummy
+      minHeight={minHeight}
+      disableAnimation={disableAnimation}
+      controlAsFunc={controlAsFunc}
+      defaultExpanded={defaultExpanded}
+    />,
+  );
 }
 
 describe('<Collapse />', () => {
@@ -126,5 +135,13 @@ describe('<Collapse />', () => {
     const content = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
 
     content.className.should.not.include(styles.transition);
+  });
+
+  it('should be able to expand by default', () => {
+    renderComponent(0, true, false, true);
+
+    const content = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
+
+    content.should.contain.text(textMock);
   });
 });

--- a/src/collapse/collapse.test.tsx
+++ b/src/collapse/collapse.test.tsx
@@ -30,12 +30,14 @@ const Dummy = ({
   minHeight,
   disableAnimation,
   controlAsFunc,
-  defaultExpanded = false,
+  defaultCollapsed = true,
+  collapsed = null,
 }: {
   minHeight: number;
   disableAnimation: boolean;
   controlAsFunc: boolean;
-  defaultExpanded: boolean;
+  defaultCollapsed: boolean;
+  collapsed: boolean | null;
 }) => {
   const [texts, setTexts] = useState([textMock]);
 
@@ -44,12 +46,17 @@ const Dummy = ({
       <button type="button" onClick={() => setTexts([...texts, textMock])}>
         {'More text'}
       </button>
-      <Collapse onChange={onChangeMock} disableAnimation={disableAnimation} defaultExpanded={defaultExpanded}>
+      <Collapse
+        onChange={onChangeMock}
+        disableAnimation={disableAnimation}
+        defaultCollapsed={defaultCollapsed}
+        collapsed={collapsed}
+      >
         <CollapseControl>
           {controlAsFunc ? (
             <button type="button">{'Show text'}</button>
           ) : (
-            (collapsed: boolean) => <button type="button">{collapsed ? 'Show text' : 'Hide text'}</button>
+            (isCollapsed: boolean) => <button type="button">{isCollapsed ? 'Show text' : 'Hide text'}</button>
           )}
         </CollapseControl>
         <CollapseContent minHeight={minHeight}>
@@ -63,13 +70,20 @@ const Dummy = ({
   );
 };
 
-function renderComponent(minHeight = 0, disableAnimation = false, controlAsFunc = false, defaultExpanded = false) {
+function renderComponent(
+  minHeight = 0,
+  disableAnimation = false,
+  controlAsFunc = false,
+  defaultCollapsed = true,
+  collapsed = null,
+) {
   return render(
     <Dummy
       minHeight={minHeight}
       disableAnimation={disableAnimation}
       controlAsFunc={controlAsFunc}
-      defaultExpanded={defaultExpanded}
+      defaultCollapsed={defaultCollapsed}
+      collapsed={collapsed}
     />,
   );
 }
@@ -138,7 +152,7 @@ describe('<Collapse />', () => {
   });
 
   it('should be able to expand by default', () => {
-    renderComponent(0, true, false, true);
+    renderComponent(0, true, false, false);
 
     const content = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
 

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -9,6 +9,7 @@ type Props = {
   duration?: number;
   disableAnimation?: boolean;
   className?: string;
+  defaultExpanded?: boolean;
 };
 
 /**
@@ -21,8 +22,9 @@ export const Collapse: React.FC<PropsWithChildren<Props>> = ({
   disableAnimation = false,
   className = '',
   onChange = () => {},
+  defaultExpanded = false,
 }) => {
-  const [collapsed, toggle] = useState(true);
+  const [collapsed, toggle] = useState(!defaultExpanded);
   const id = useId();
 
   const setCollapsed = useCallback(() => {

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -1,4 +1,4 @@
-import {PropsWithChildren, useCallback, useId, useState} from 'react';
+import {PropsWithChildren, useCallback, useId, useMemo, useState} from 'react';
 import * as React from 'react';
 
 import {CollapseContext} from './collapse-context';
@@ -9,7 +9,8 @@ type Props = {
   duration?: number;
   disableAnimation?: boolean;
   className?: string;
-  defaultExpanded?: boolean;
+  defaultCollapsed?: boolean;
+  collapsed?: boolean | null;
 };
 
 /**
@@ -22,21 +23,24 @@ export const Collapse: React.FC<PropsWithChildren<Props>> = ({
   disableAnimation = false,
   className = '',
   onChange = () => {},
-  defaultExpanded = false,
+  defaultCollapsed = true,
+  collapsed = null,
 }) => {
-  const [collapsed, toggle] = useState(!defaultExpanded);
+  const [innerCollapsed, setInnerCollapsed] = useState(defaultCollapsed);
   const id = useId();
 
+  const finalCollapsedValue = useMemo(() => collapsed ?? innerCollapsed, [innerCollapsed, collapsed]);
+
   const setCollapsed = useCallback(() => {
-    toggle(!collapsed);
-    onChange(!collapsed);
-  }, [toggle, onChange, collapsed]);
+    setInnerCollapsed(!finalCollapsedValue);
+    onChange(!finalCollapsedValue);
+  }, [setInnerCollapsed, onChange, finalCollapsedValue]);
 
   return (
     <div className={className}>
       <CollapseContext.Provider
         value={{
-          collapsed,
+          collapsed: finalCollapsedValue,
           setCollapsed,
           duration,
           disableAnimation,


### PR DESCRIPTION
## Description
One of the users requested to stop rendering the content after the collapsed component was collapsed.

## Implementation
Since the Collapse component has animation, I am using the `transitionend` event to track whenever the content is hidden, which helps to understand when the content can be hidden.

## API Changes

### Collapse
| Attribute | Type                         | Description                                                                      | Default |
|-----------|------------------------------|----------------------------------------------------------------------------------|---------|
| defaultCollapsed  | boolean                    | This prop controls whether the collapse component should be expanded by default.              | false       |
| collapsed  | boolean \| null                    | This prop controls the collapsing state.              | null       |

### Basic usage of the defaultCollapsed prop
```tsx
<Collapse defaultCollapsed>
 <CollapseControl>
  <Button>Show</Button>
 </CollapseControl>
 <CollapseContent>{text}</CollapseContent>
</Collapse>
```

### Basic usage of the collapsed prop
```tsx
const [collapsed, toggle] = useState(true);

const onClick = () => {
   toggle(!collapsed);
};

<Button data-test="trigger" onClick={onClick}>
  {collapsed ? 'Show more' : 'Show less'}
</Button>

<Collapse collapsed={collapsed}>
 <CollapseContent>{text}</CollapseContent>
</Collapse>
```