### PR TITLE
chore(eslint): rely on tsconfig on functions returns

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,6 +77,8 @@ export default tseslint.config(
       'valid-jsdoc': 0,
       'import/no-commonjs': 0,
 
+      'consistent-return': 0, // as we rely on tsconfig's noImplicitReturns
+
       'import/no-extraneous-dependencies': [
         2,
         {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,7 @@
     /* Additional Checks */
     // "noUnusedLocals": true,                      /* Report errors on unused locals. */
     // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
     // "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */


### PR DESCRIPTION
`@jetbrains-eslint/base` config [brings](https://github.com/JetBrains/eslint-config/blob/2536514f81ee4bef52640edd13f1b7697b3b737b/base.js#L36) `consistent-returns` rule which is not convenient in scope of React + TS. We can leverage return consistency on `tsconfig` as proposed in this PR and plus it helps avoiding unnecessary branching as shown [here](https://github.com/JetBrains/ring-ui/blob/0c3031128e75ad7a7d122194991bf42906d58553/src/collapse/collapse-content.tsx#L55-L61)