### PR TITLE
create an isolated z-index context for button-group

### DIFF
--- a/src/button-group/button-group.css
+++ b/src/button-group/button-group.css
@@ -11,6 +11,9 @@
 }
 
 .common {
+  position: relative;
+  z-index: 0; /* this creates an isolated z-index context */
+
   display: inline-block;
 
   white-space: nowrap;
@@ -143,9 +146,6 @@
 .split {
   composes: common;
   composes: buttonGroup from "../button-toolbar/button-toolbar.css";
-
-  position: relative;
-  z-index: 0;
 }
 
 .common button,


### PR DESCRIPTION
This prevents selected buttons from appearing above items with --ring-fixed-z-index