### PR TITLE
Remove QuickAssist placeholder from tab order

### DIFF
--- a/src/query-assist/query-assist.tsx
+++ b/src/query-assist/query-assist.tsx
@@ -1093,6 +1093,7 @@ export default class QueryAssist extends Component<QueryAssistProps> {
                   onClick={this.handleCaretMove}
                   data-test="query-assist-placeholder"
                   disabled={this.props.disabled}
+                  tabIndex={-1}
                 >
                   {this.props.placeholder}
                 </button>


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/8f6dae09-de5b-4676-9b3e-9763d9da271e

After:


https://github.com/user-attachments/assets/77ee93f4-3747-4b67-9076-d6841873d652

