### PR TITLE
RG-2525 feat(DropdownMenu): accept children

### DIFF
--- a/packages/screenshots/testplane/chrome/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dark.png
+++ b/packages/screenshots/testplane/chrome/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c548f62addf75185286b7fb0c271cfca05e384b31a6d229c7808e11170517d3f
+size 982

--- a/packages/screenshots/testplane/chrome/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dropdown.png
+++ b/packages/screenshots/testplane/chrome/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dropdown.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c0713e2bce71a341763661f0577b0760a4dea2d813a37829e14c64b37672ed0
+size 1862

--- a/packages/screenshots/testplane/firefox/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dark.png
+++ b/packages/screenshots/testplane/firefox/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74a93327408da03fafae1dfc1fb5aa79d118567a042780e82ed6b039caa15fdb
+size 1747

--- a/packages/screenshots/testplane/firefox/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dropdown.png
+++ b/packages/screenshots/testplane/firefox/components/dropdownmenu/dropdownmenu with custom children/dropdownmenu with custom children-dropdown.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07bd9adca89714fd3cac63717fac9414358e76f9fd7967390791dd70474f6fbd
+size 3187

--- a/src/dropdown-menu/dropdown-menu.stories.tsx
+++ b/src/dropdown-menu/dropdown-menu.stories.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 
 import chevronRight from '@jetbrains/icons/chevron-right';
 
+import List from '../list/list';
+
 import {Directions} from '../popup/popup.consts';
 import Icon from '../icon';
 import Group from '../group/group';
 
 import {ListDataItem} from '../list/consts';
+
+import PopupMenu from '../popup-menu/popup-menu';
 
 import DropdownMenu, {DropdownMenuProps} from './dropdown-menu';
 
@@ -192,3 +196,29 @@ nested.parameters = {
   }
 </style>`,
 };
+
+export const withCustomChildren = () => {
+  return (
+    <DropdownMenu anchor={'Click me'} menuProps={{closeOnSelect: false}}>
+      {props => (
+        <PopupMenu
+          data={[
+            {
+              rgItemType: List.ListProps.Type.CUSTOM,
+              template: (
+                <DropdownMenu
+                  data={[{label: 'Sub-item 1'}, {label: 'Sub-item 2'}]}
+                  anchor={'Submenu'}
+                  onSelect={() => props.onCloseAttempt?.()}
+                />
+              ),
+            },
+          ]}
+          {...props}
+        />
+      )}
+    </DropdownMenu>
+  );
+};
+
+withCustomChildren.storyName = 'DropdownMenu with custom children';

--- a/src/dropdown-menu/dropdown-menu.stories.tsx
+++ b/src/dropdown-menu/dropdown-menu.stories.tsx
@@ -202,6 +202,7 @@ export const withCustomChildren = () => {
     <DropdownMenu anchor={'Click me'} menuProps={{closeOnSelect: false}}>
       {props => (
         <PopupMenu
+          {...props}
           data={[
             {
               rgItemType: List.ListProps.Type.CUSTOM,
@@ -214,7 +215,6 @@ export const withCustomChildren = () => {
               ),
             },
           ]}
-          {...props}
         />
       )}
     </DropdownMenu>

--- a/src/dropdown-menu/dropdown-menu.tsx
+++ b/src/dropdown-menu/dropdown-menu.tsx
@@ -1,7 +1,7 @@
 import {forwardRef, useMemo, cloneElement, ReactElement, HTMLAttributes, SyntheticEvent, Ref, ReactNode} from 'react';
 
 import List, {ActiveItemContext, SelectHandlerParams} from '../list/list';
-import Dropdown, {AnchorProps, DropdownAttrs, DropdownChildren} from '../dropdown/dropdown';
+import Dropdown, {AnchorProps, DropdownAttrs, DropdownChildrenFunction} from '../dropdown/dropdown';
 import PopupMenu, {PopupMenuAttrs} from '../popup-menu/popup-menu';
 import {PopupAttrs} from '../popup/popup';
 import getUID from '../global/get-uid';
@@ -24,7 +24,7 @@ export interface DropdownAnchorWrapperProps extends AnchorProps {
 }
 
 interface DropdownMenuChildren<T> {
-  children?: DropdownChildren;
+  children?: DropdownChildrenFunction;
   popupMenuProps: {
     ref: Ref<PopupMenu<T>>;
     data: readonly ListDataItem<T>[] | undefined;
@@ -76,11 +76,7 @@ function renderDropdownMenuChildren<T>({children, popupMenuProps}: DropdownMenuC
   if (!children) {
     return <PopupMenu {...popupMenuProps} />;
   }
-  if (typeof children === 'function') {
-    const {data, ...restPopupMenuProps} = popupMenuProps;
-    return (popupProps: Omit<PopupAttrs, 'children'>) => children({...popupProps, ...restPopupMenuProps});
-  }
-  return cloneElement(children as ReactElement<PopupAttrs>, popupMenuProps);
+  return (popupProps: Omit<PopupAttrs, 'children'>) => children({...popupProps, ...popupMenuProps});
 }
 
 type OnSelectHandler<T> =
@@ -97,7 +93,7 @@ export interface DropdownMenuProps<T = unknown> extends Omit<DropdownAttrs, 'anc
   ariaLabel?: string | null | undefined;
   onSelect?: OnSelectHandler<T>;
   menuProps?: PopupMenuAttrs<T> | null | undefined;
-  children?: DropdownChildren;
+  children?: DropdownChildrenFunction;
 }
 
 const DropdownMenu = forwardRef(function DropdownMenu<T = unknown>(

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -23,7 +23,9 @@ export interface DropdownChildProps {
   dontCloseOnAnchorClick: boolean;
 }
 
-export type DropdownChildren = ReactElement<PopupAttrs> | ((props: Omit<PopupAttrs, 'children'>) => ReactNode);
+export type DropdownChildrenFunction = (props: Omit<PopupAttrs, 'children'>) => ReactNode;
+
+export type DropdownChildren = ReactElement<PopupAttrs> | DropdownChildrenFunction;
 
 export interface DropdownProps extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   /**

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -23,13 +23,15 @@ export interface DropdownChildProps {
   dontCloseOnAnchorClick: boolean;
 }
 
+export type DropdownChildren = ReactElement<PopupAttrs> | ((props: Omit<PopupAttrs, 'children'>) => ReactNode);
+
 export interface DropdownProps extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   /**
    * Can be string, React element, or a function accepting an object with {active, pinned} properties and returning a React element
    * React element should render some interactive HTML element like `button` or `a`
    */
   anchor: ReactElement | readonly ReactElement[] | string | ((props: AnchorProps) => ReactNode);
-  children: ReactElement<PopupAttrs> | ((props: Omit<PopupAttrs, 'children'>) => ReactNode);
+  children: DropdownChildren;
   initShown: boolean;
   disabled?: boolean | null | undefined;
   clickMode: boolean;

--- a/src/header/profile.tsx
+++ b/src/header/profile.tsx
@@ -28,7 +28,7 @@ export interface ProfileTranslations {
   certificateMismatch?: string | null | undefined;
 }
 
-export interface ProfileProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+export interface ProfileProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onSelect' | 'children'> {
   closeOnSelect: boolean;
   renderPopupItems: (items: ListDataItem[]) => readonly ListDataItem[];
   translations?: ProfileTranslations | null | undefined;


### PR DESCRIPTION
So it makes it possible to access `popupProps` and call methods from it, e.g. `onCloseAttempt`.

Case: when one renders `DropdownMenu` inside of a `DropdownMenu` and wants to close the parent `DropdownMenu` on the children's select. Otherwise consumer have to stop event propagation on the wrapper level, and create hackish solutions such as `DropdownMenu` key re-generation on `onSelect` calls.  Example in story. 