### PR TITLE
chore: replace outdated generic system mac font families

### DIFF
--- a/packages/screenshots/testplane/chrome/style-only/old browsers message/old browsers message/old browsers message-dark.png
+++ b/packages/screenshots/testplane/chrome/style-only/old browsers message/old browsers message/old browsers message-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a6fa1d48913efa4f829793176ff4c00dcddf56033cc9f5667c1ebb365ea711c
-size 4087
+oid sha256:6ebf816929a7365d29c8a0ae1519d5e74761e516361cf09581fc966b09a01371
+size 4109

--- a/packages/screenshots/testplane/chrome/style-only/old browsers message/old browsers message/old browsers message.png
+++ b/packages/screenshots/testplane/chrome/style-only/old browsers message/old browsers message/old browsers message.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f23a93e7450ca38cb8213b9818758edb46418a7e9b233309b167cadd65068bbc
-size 2956
+oid sha256:a915893377c5804ef03b629ecd26e2e8468b9dcefb9583a8ceea10271ffdc69c
+size 2924

--- a/src/old-browsers-message/old-browsers-message.css
+++ b/src/old-browsers-message/old-browsers-message.css
@@ -9,7 +9,7 @@
 
   color: var(--ring-text-color);
 
-  font-family: -apple-system, BlinkMacSystemFont, Ubuntu, "Helvetica Neue", Arial, sans-serif;
+  font-family: system-ui, Ubuntu, "Helvetica Neue", Arial, sans-serif;
   font-size: var(--ring-font-size-larger);
   line-height: calc(2.5 * var(--ring-unit));
 }


### PR DESCRIPTION
This PR replaces outdated fallback font families for MacOS with the 'modern' one.