### PR TITLE
Use React.JSX instead of JSX

### DIFF
--- a/src/auth-dialog-service/auth-dialog-service.tsx
+++ b/src/auth-dialog-service/auth-dialog-service.tsx
@@ -11,7 +11,7 @@ import AuthDialog, {AuthDialogProps} from '../auth-dialog/auth-dialog';
 const containerElement = document.createElement('div');
 export const reactRoot = createRoot(containerElement);
 
-type AuthDialogAttributes = JSX.LibraryManagedAttributes<typeof AuthDialog, AuthDialogProps>
+type AuthDialogAttributes = React.JSX.LibraryManagedAttributes<typeof AuthDialog, AuthDialogProps>
 
 /**
  * Renders AuthDialog into virtual node to skip maintaining container

--- a/src/avatar/avatar.tsx
+++ b/src/avatar/avatar.tsx
@@ -179,4 +179,4 @@ export default class Avatar extends PureComponent<AvatarProps> {
   }
 }
 
-export type AvatarAttrs = JSX.LibraryManagedAttributes<typeof Avatar, AvatarProps>;
+export type AvatarAttrs = React.JSX.LibraryManagedAttributes<typeof Avatar, AvatarProps>;

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -159,7 +159,8 @@ export class Button extends PureComponent<ButtonProps> {
 
 export {Size as IconSize};
 
-export type ContainerProps<T extends ButtonProps> = JSX.LibraryManagedAttributes<typeof Button, T>
+export type ContainerProps<T extends ButtonProps> =
+  React.JSX.LibraryManagedAttributes<typeof Button, T>
 
 export type ButtonAttrs = ContainerProps<ButtonButtonProps> | ContainerProps<ButtonLinkProps>
 

--- a/src/checkbox/checkbox.test.tsx
+++ b/src/checkbox/checkbox.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import Checkbox, {CheckboxProps} from './checkbox';
 
-type CheckboxAttributes = JSX.LibraryManagedAttributes<typeof Checkbox, CheckboxProps>
+type CheckboxAttributes = React.JSX.LibraryManagedAttributes<typeof Checkbox, CheckboxProps>
 
 describe('Checkbox', () => {
   const renderCheckbox = (props?: CheckboxAttributes) => {

--- a/src/code/code.test.tsx
+++ b/src/code/code.test.tsx
@@ -9,7 +9,7 @@ highlight.registerLanguage('css', css);
 highlight.registerLanguage('javascript', javascript);
 highlight.registerLanguage('xml', xml);
 
-type CodeAttributes = JSX.LibraryManagedAttributes<typeof Code, CodeProps>
+type CodeAttributes = React.JSX.LibraryManagedAttributes<typeof Code, CodeProps>
 
 describe('Code', () => {
   const renderCode = (props?: Omit<CodeAttributes, 'code'> & Partial<Pick<CodeAttributes, 'code'>>) => {

--- a/src/confirm/confirm.tsx
+++ b/src/confirm/confirm.tsx
@@ -119,4 +119,4 @@ export default class Confirm extends PureComponent<ConfirmProps> {
   }
 }
 
-export type ConfirmAttributes = JSX.LibraryManagedAttributes<typeof Confirm, ConfirmProps>
+export type ConfirmAttributes = React.JSX.LibraryManagedAttributes<typeof Confirm, ConfirmProps>

--- a/src/contenteditable/contenteditable.tsx
+++ b/src/contenteditable/contenteditable.tsx
@@ -66,7 +66,10 @@ class ContentEditableBase extends Component<ContentEditableBaseProps> {
 }
 
 type ContentEditableBaseAttrs =
-  JSX.LibraryManagedAttributes<typeof ContentEditableBase, ContentEditableBaseProps>
+  React.JSX.LibraryManagedAttributes<
+  typeof ContentEditableBase,
+  ContentEditableBaseProps
+>
 
 export type ContentEditableProps = Omit<ContentEditableBaseAttrs, '__html'>
 

--- a/src/data-list/item.tsx
+++ b/src/data-list/item.tsx
@@ -216,7 +216,8 @@ export default class Item<T extends SelectionItem> extends PureComponent<ItemPro
   }
 }
 
-type ItemAttrs<T extends SelectionItem> = JSX.LibraryManagedAttributes<typeof Item, ItemProps<T>>
+type ItemAttrs<T extends SelectionItem>
+  = React.JSX.LibraryManagedAttributes<typeof Item, ItemProps<T>>
 (Item as ComponentType<ItemAttrs<SelectionItem>>).propTypes = {
   item: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired

--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -352,4 +352,4 @@ export default class DatePicker extends PureComponent<DatePickerProps> {
   }
 }
 
-export type DatePickerAttrs = JSX.LibraryManagedAttributes<typeof DatePicker, DatePickerProps>
+export type DatePickerAttrs = React.JSX.LibraryManagedAttributes<typeof DatePicker, DatePickerProps>

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -235,6 +235,6 @@ export default class Dropdown extends Component<DropdownProps, DropdownState> {
   }
 }
 
-export type DropdownAttrs = JSX.LibraryManagedAttributes<typeof Dropdown, DropdownProps>
+export type DropdownAttrs = React.JSX.LibraryManagedAttributes<typeof Dropdown, DropdownProps>
 
 export {Anchor};

--- a/src/global/focus-sensor-hoc.tsx
+++ b/src/global/focus-sensor-hoc.tsx
@@ -38,7 +38,7 @@ export type FocusSensorProps<
   P extends FocusSensorAddProps<T>,
   T extends HTMLElement,
   C extends ComponentType<P>
-> = RestProps<JSX.LibraryManagedAttributes<C, P>, T> & FocusSensorOuterProps<T>
+> = RestProps<React.JSX.LibraryManagedAttributes<C, P>, T> & FocusSensorOuterProps<T>
 
 export default function focusSensorHOC<
   T extends HTMLElement,
@@ -135,7 +135,7 @@ export default function focusSensorHOC<
         this.props;
       return (
         <ComposedComponent
-          {...rest as JSX.LibraryManagedAttributes<C, P>}
+          {...rest as React.JSX.LibraryManagedAttributes<C, P>}
           innerRef={this.composedRef(innerRef, this.onRefUpdate)}
           focused={this.state.focused}
           onFocusReset={this.onFocusReset}

--- a/src/header/header.tsx
+++ b/src/header/header.tsx
@@ -58,7 +58,7 @@ class Header extends Component<HeaderProps> {
   }
 }
 
-export type HeaderAttrs = JSX.LibraryManagedAttributes<typeof Header, HeaderProps>;
+export type HeaderAttrs = React.JSX.LibraryManagedAttributes<typeof Header, HeaderProps>;
 export default Header;
 export {default as Logo} from './logo';
 export {default as Tray} from './tray';

--- a/src/header/profile.tsx
+++ b/src/header/profile.tsx
@@ -250,4 +250,4 @@ export default class Profile extends PureComponent<ProfileProps> {
   }
 }
 
-export type ProfileAttrs = JSX.LibraryManagedAttributes<typeof Profile, ProfileProps>
+export type ProfileAttrs = React.JSX.LibraryManagedAttributes<typeof Profile, ProfileProps>

--- a/src/icon/icon.tsx
+++ b/src/icon/icon.tsx
@@ -106,6 +106,6 @@ export default class Icon extends PureComponent<IconProps> {
   }
 }
 
-export type IconAttrs = JSX.LibraryManagedAttributes<typeof Icon, IconProps>
+export type IconAttrs = React.JSX.LibraryManagedAttributes<typeof Icon, IconProps>
 
 export {Color, Size};

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -300,7 +300,8 @@ export class Input extends PureComponent<InputProps> {
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType])
 };
 
-export type ContainerProps<P extends InputProps> = JSX.LibraryManagedAttributes<typeof Input, P>
+export type ContainerProps<P extends InputProps> =
+  React.JSX.LibraryManagedAttributes<typeof Input, P>
 
 export type InputSpecificAttrs = ContainerProps<InputSpecificProps>;
 export type TextAreaSpecificAttrs = ContainerProps<TextAreaSpecificProps>;

--- a/src/list/consts.ts
+++ b/src/list/consts.ts
@@ -58,7 +58,7 @@ export type ListDataItem<T = unknown> =
   label?: ReactNode
   rightNodes?: ReactNode
   leftNodes?: ReactNode
-  tagName?: keyof JSX.IntrinsicElements | null | undefined
+  tagName?: keyof React.JSX.IntrinsicElements | null | undefined
   selectedLabel?: string | null | undefined,
   originalModel?: never
   LinkComponent?: ComponentType<ClickableLinkProps> | string | null | undefined

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -863,4 +863,4 @@ export default class List<T = unknown> extends Component<ListProps<T>, ListState
   }
 }
 
-export type ListAttrs<T = unknown> = JSX.LibraryManagedAttributes<typeof List, ListProps<T>>
+export type ListAttrs<T = unknown> = React.JSX.LibraryManagedAttributes<typeof List, ListProps<T>>

--- a/src/list/list__custom.tsx
+++ b/src/list/list__custom.tsx
@@ -48,7 +48,7 @@ export default class ListCustom<T> extends PureComponent<ListDataItemProps<T>> {
     const content: ReactNode = (typeof template === 'function')
       ? template(this.props as ListDataItemProps<T>)
       : template;
-    const TagName: keyof JSX.IntrinsicElements = tagName || 'span';
+    const TagName: keyof React.JSX.IntrinsicElements = tagName || 'span';
 
     return (
       <TagName

--- a/src/loader-inline/loader-inline.tsx
+++ b/src/loader-inline/loader-inline.tsx
@@ -49,5 +49,5 @@ class LoaderInline extends PureComponent<LoaderInlineProps> {
 }
 
 export type LoaderInlineAtrrs =
-  JSX.LibraryManagedAttributes<typeof LoaderInline, LoaderInlineProps>;
+  React.JSX.LibraryManagedAttributes<typeof LoaderInline, LoaderInlineProps>;
 export default LoaderInline;

--- a/src/login-dialog/login-dialog.tsx
+++ b/src/login-dialog/login-dialog.tsx
@@ -136,4 +136,5 @@ export default class LoginDialog extends Component<LoginDialogProps> {
   }
 }
 
-export type LoginDialogAttrs = JSX.LibraryManagedAttributes<typeof LoginDialog, LoginDialogProps>
+export type LoginDialogAttrs =
+  React.JSX.LibraryManagedAttributes<typeof LoginDialog, LoginDialogProps>

--- a/src/message/message.tsx
+++ b/src/message/message.tsx
@@ -216,4 +216,4 @@ export default class Message extends Component<MessageProps> {
   translations: PropTypes.object
 };
 
-export type MessageAttrs = JSX.LibraryManagedAttributes<typeof Message, MessageProps>
+export type MessageAttrs = React.JSX.LibraryManagedAttributes<typeof Message, MessageProps>

--- a/src/pager/pager.tsx
+++ b/src/pager/pager.tsx
@@ -359,4 +359,4 @@ export default class Pager extends PureComponent<PagerProps> {
   hrefFunc: PropTypes.func //function which generates href for all pager's buttons based on pager state passed as a function parameter, either this function or onPageChange should be provided
 };
 
-export type PagerAttrs = JSX.LibraryManagedAttributes<typeof Pager, PagerProps>
+export type PagerAttrs = React.JSX.LibraryManagedAttributes<typeof Pager, PagerProps>

--- a/src/popup-menu/popup-menu.tsx
+++ b/src/popup-menu/popup-menu.tsx
@@ -65,6 +65,6 @@ export default class PopupMenu<T = unknown> extends Popup<PopupMenuProps<T>> {
 };
 
 export type PopupMenuAttrs<T = unknown> =
-  JSX.LibraryManagedAttributes<typeof PopupMenu, PopupMenuProps<T>>
+  React.JSX.LibraryManagedAttributes<typeof PopupMenu, PopupMenuProps<T>>
 
 export const {ListProps} = List;

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -503,5 +503,5 @@ export default class Popup<
   autoFocusFirst: PropTypes.bool
 };
 
-export type PopupAttrs = JSX.LibraryManagedAttributes<typeof Popup, PopupProps>
-export type BasePopupAttrs = JSX.LibraryManagedAttributes<typeof Popup, BasePopupProps>;
+export type PopupAttrs = React.JSX.LibraryManagedAttributes<typeof Popup, PopupProps>
+export type BasePopupAttrs = React.JSX.LibraryManagedAttributes<typeof Popup, BasePopupProps>;

--- a/src/progress-bar/progress-bar.tsx
+++ b/src/progress-bar/progress-bar.tsx
@@ -113,4 +113,5 @@ export default class ProgressBar extends PureComponent<ProgressBarProps> {
   }
 }
 
-export type ProgressBarAttrs = JSX.LibraryManagedAttributes<typeof ProgressBar, ProgressBarProps>
+export type ProgressBarAttrs =
+  React.JSX.LibraryManagedAttributes<typeof ProgressBar, ProgressBarProps>

--- a/src/query-assist/query-assist.tsx
+++ b/src/query-assist/query-assist.tsx
@@ -1197,6 +1197,7 @@ export default class QueryAssist extends Component<QueryAssistProps> {
   }
 }
 
-export type QueryAssistAttrs = JSX.LibraryManagedAttributes<typeof QueryAssist, QueryAssistProps>;
+export type QueryAssistAttrs
+  = React.JSX.LibraryManagedAttributes<typeof QueryAssist, QueryAssistProps>;
 
 export const RerenderableQueryAssist = rerenderHOC(QueryAssist);

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -1567,9 +1567,10 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
 };
 
 export type SingleSelectAttrs<T = unknown> =
-  JSX.LibraryManagedAttributes<typeof Select, SingleSelectProps<T>>
+  React.JSX.LibraryManagedAttributes<typeof Select, SingleSelectProps<T>>
 export type MultipleSelectAttrs<T = unknown> =
-  JSX.LibraryManagedAttributes<typeof Select, MultipleSelectProps<T>>
-export type SelectAttrs<T = unknown> = JSX.LibraryManagedAttributes<typeof Select, SelectProps<T>>
+  React.JSX.LibraryManagedAttributes<typeof Select, MultipleSelectProps<T>>
+export type SelectAttrs<T = unknown>
+  = React.JSX.LibraryManagedAttributes<typeof Select, SelectProps<T>>
 
 export const RerenderableSelect = rerenderHOC(Select);

--- a/src/select/select__popup.tsx
+++ b/src/select/select__popup.tsx
@@ -717,4 +717,4 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
 };
 
 export type SelectPopupAttrs<T = unknown> =
-  JSX.LibraryManagedAttributes<typeof SelectPopup, SelectPopupProps<T>>
+  React.JSX.LibraryManagedAttributes<typeof SelectPopup, SelectPopupProps<T>>

--- a/src/shortcuts/shortcuts.test.tsx
+++ b/src/shortcuts/shortcuts.test.tsx
@@ -5,7 +5,7 @@ import getUID from '../global/get-uid';
 
 import Shortcuts, {ShortcutsProps} from './shortcuts';
 
-type ShortcutsAttrs = JSX.LibraryManagedAttributes<typeof Shortcuts, ShortcutsProps>
+type ShortcutsAttrs = React.JSX.LibraryManagedAttributes<typeof Shortcuts, ShortcutsProps>
 type FactoryProps = Omit<ShortcutsAttrs, 'map' | 'scope'>
 
 describe('ShortcutsComponent', () => {

--- a/src/table/header.tsx
+++ b/src/table/header.tsx
@@ -142,4 +142,4 @@ export default class Header extends PureComponent<HeaderProps> {
   }
 }
 
-export type HeaderAttrs = JSX.LibraryManagedAttributes<typeof Header, HeaderProps>
+export type HeaderAttrs = React.JSX.LibraryManagedAttributes<typeof Header, HeaderProps>

--- a/src/table/row.tsx
+++ b/src/table/row.tsx
@@ -297,4 +297,4 @@ export default class Row<T extends SelectionItem> extends PureComponent<RowProps
 };
 
 export type RowAttrs<T extends SelectionItem> =
-  JSX.LibraryManagedAttributes<typeof Row, RowProps<T>>;
+  React.JSX.LibraryManagedAttributes<typeof Row, RowProps<T>>;

--- a/src/tabs/dumb-tabs.tsx
+++ b/src/tabs/dumb-tabs.tsx
@@ -116,5 +116,5 @@ class Tabs extends PureComponent<TabsProps> {
     );
   }
 }
-export type TabsAttrs = JSX.LibraryManagedAttributes<typeof Tabs, TabsProps>
+export type TabsAttrs = React.JSX.LibraryManagedAttributes<typeof Tabs, TabsProps>
 export default Tabs;

--- a/src/tag/tag.tsx
+++ b/src/tag/tag.tsx
@@ -216,4 +216,4 @@ export default class Tag extends PureComponent<TagProps> {
   }
 }
 
-export type TagAttrs = JSX.LibraryManagedAttributes<typeof Tag, TagProps>
+export type TagAttrs = React.JSX.LibraryManagedAttributes<typeof Tag, TagProps>

--- a/src/tags-input/tags-input.tsx
+++ b/src/tags-input/tags-input.tsx
@@ -432,4 +432,4 @@ export default class TagsInput extends PureComponent<TagsInputProps, TagsInputSt
 }
 
 export const RerenderableTagsInput = rerenderHOC(TagsInput);
-export type TagsInputAttrs = JSX.LibraryManagedAttributes<typeof TagsInput, TagsInputProps>
+export type TagsInputAttrs = React.JSX.LibraryManagedAttributes<typeof TagsInput, TagsInputProps>

--- a/src/tags-list/tags-list.tsx
+++ b/src/tags-list/tags-list.tsx
@@ -106,4 +106,4 @@ export default class TagsList<T extends TagType> extends Component<TagsListProps
 }
 
 export type TagsListAttrs<T extends TagType = TagType> =
-  JSX.LibraryManagedAttributes<typeof TagsList, TagsListProps<T>>
+  React.JSX.LibraryManagedAttributes<typeof TagsList, TagsListProps<T>>

--- a/src/toggle/toggle.tsx
+++ b/src/toggle/toggle.tsx
@@ -92,5 +92,5 @@ class Toggle extends PureComponent<ToggleProps> {
     );
   }
 }
-export type ToggleAttrs = JSX.LibraryManagedAttributes<typeof Toggle, ToggleProps>
+export type ToggleAttrs = React.JSX.LibraryManagedAttributes<typeof Toggle, ToggleProps>
 export default Toggle;

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -205,4 +205,4 @@ export default class Tooltip extends Component<TooltipProps> {
     );
   }
 }
-export type TooltipAttrs = JSX.LibraryManagedAttributes<typeof Tooltip, TooltipProps>
+export type TooltipAttrs = React.JSX.LibraryManagedAttributes<typeof Tooltip, TooltipProps>

--- a/src/user-agreement/user-agreement.tsx
+++ b/src/user-agreement/user-agreement.tsx
@@ -149,4 +149,4 @@ export default class UserAgreement extends PureComponent<UserAgreementProps> {
   }
 }
 export type UserAgreementAttrs =
-  JSX.LibraryManagedAttributes<typeof UserAgreement, UserAgreementProps>
+  React.JSX.LibraryManagedAttributes<typeof UserAgreement, UserAgreementProps>

--- a/src/user-card/card.tsx
+++ b/src/user-card/card.tsx
@@ -183,4 +183,4 @@ export default class UserCard extends PureComponent<UserCardProps> {
     );
   }
 }
-export type UserCardAttrs = JSX.LibraryManagedAttributes<typeof UserCard, UserCardProps>
+export type UserCardAttrs = React.JSX.LibraryManagedAttributes<typeof UserCard, UserCardProps>

--- a/src/user-card/tooltip.tsx
+++ b/src/user-card/tooltip.tsx
@@ -76,4 +76,4 @@ export default class UserCardTooltip extends Component<UserCardTooltipProps> {
   }
 }
 export type UserCardTooltipAttrs =
-  JSX.LibraryManagedAttributes<typeof UserCardTooltip, UserCardTooltipProps>
+  React.JSX.LibraryManagedAttributes<typeof UserCardTooltip, UserCardTooltipProps>


### PR DESCRIPTION
I cherry-picked https://github.com/JetBrains/ring-ui/commit/086da3ea4aeecd8d5a288a303186368936ba4525 to `release-6.x`, so we can try to use Ring UI 6.x with React 19.

`JSX` is deprecated in favor of `React.JSX` https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript.