### PR TITLE
Fix List shouldComponentUpdate

### DIFF
--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -193,7 +193,7 @@ export default class List<T = unknown> extends Component<ListProps<T>, ListState
 
   shouldComponentUpdate(nextProps: ListProps<T>, nextState: ListState<T>) {
     return (
-      nextProps !== this.props ||
+      (Object.keys(nextProps) as Array<keyof ListProps<T>>).some(key => !Object.is(nextProps[key], this.props[key])) ||
       (Object.keys(nextState) as Array<keyof ListState>).some(key => nextState[key] !== this.state[key])
     );
   }


### PR DESCRIPTION
`nextProps !== this.props` is always `true` in React 19, so `setState` in `componentDidUpdate` results in an infinite loop. I also use `Object.is` because the `maxHeight` prop can contain `NaN`, `NaN` !== `NaN`.