### PR TITLE
Add "exports" field to better support native ESM environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,17 @@
     "jslint-xml.js",
     "typings.d.ts"
   ],
-  "main": "src/index.js",
+  "exports": {
+    "./*.js": "./*.js",
+    "./*.css": "./*.css",
+    "./*.d.ts": "./*.d.ts",
+    "./*.svg": "./*.svg",
+    "./*.gif": "./*.gif",
+    "./*.json": "./*.json",
+    "./*.md": "./*.md",
+    "./components/icon": "./components/icon/index.js",
+    "./*": "./*.js"
+  },
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
Without this change, you would have to specify extensions for Ring UI imports if you're using ESM (type module or .mjs)

```
ERROR in ./node_modules/@jetbrains/teamcity-ui/dist/Markdown-D1tTSe7K.mjs 3:0-76
Module not found: Error: Can't resolve '@jetbrains/ring-ui-built/components/global/normalize-indent' in '/Users/filippriabchun/WebstormProjects/teamcity-react-plugins/teamcity-cloud-plugins/hosted-plugin-server/frontend/node_modules/@jetbrains/teamcity-ui/dist'
Did you mean 'normalize-indent.js'?
BREAKING CHANGE: The request '@jetbrains/ring-ui-built/components/global/normalize-indent' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

This describes all the import paths that were possible before so it shouldn't be a breaking change, see https://nodejs.org/api/packages.html#exports:~:text=To%20make%20the%20introduction%20of%20%22exports%22%20non%2Dbreaking

This should work both with regular and built versions