### PR TITLE
RG-2197 fix auto highlight for multi select

### DIFF
--- a/packages/screenshots/testplane/chrome/components/select/multiple with a description/multiple with a description-selectwithpopup.png
+++ b/packages/screenshots/testplane/chrome/components/select/multiple with a description/multiple with a description-selectwithpopup.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:186596f9a32099fc06290b7850edf8fa7998d5a9e60931edb9fc47856003da8e
-size 6613
+oid sha256:4f7c0ce289f79fa8fdb0ec873525b531348ce0b9aab618525a4229e5b40f4933
+size 7545

--- a/packages/screenshots/testplane/firefox/components/select/multiple with a description/multiple with a description-selectwithpopup.png
+++ b/packages/screenshots/testplane/firefox/components/select/multiple with a description/multiple with a description-selectwithpopup.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59eadf122ef4879ac464afc7a4cf89d81a85cc522a6a5d141a50400c5fe395a9
-size 14168
+oid sha256:b0dd0ce89ac9ef00441837faea04268f5239436b591b5ad466300dacc6515c75
+size 14332

--- a/src/select/select.stories.tsx
+++ b/src/select/select.stories.tsx
@@ -54,24 +54,24 @@ export const withAvatars: StoryFn<SingleSelectAttrs> = args => <Select {...args}
     {label: 'Three', key: '3', type: 'user'},
     {
       label: 'With icon',
-      key: 4,
+      key: '4',
       icon: FLAG_DE_URL,
     },
     {
       label: 'With SVG icon',
-      key: 4,
+      key: 5,
       rightGlyph: warningIcon,
     },
     {
       label: 'With avatar',
-      key: 5,
+      key: 6,
       avatar: avatarUrl,
     },
     {
       label: 'With generated avatar',
       showGeneratedAvatar: true,
       username: 'With generated avatar',
-      key: 6,
+      key: 7,
     },
   ];
 


### PR DESCRIPTION
The problem occurred because activeIndex (highlighted item) was calculated before the reset button and separator were added to the list.

As a result, the highlighted item appears two positions earlier than the actual selected one (see video 1)


https://github.com/user-attachments/assets/0ea98a40-582a-4576-b90a-f0a1b31dd84f

**Current behavior (video 2):**
- Keys are now used instead of indexes to determine which item to highlight — this is safer and more stable 
- Only actual option items (not separators or reset buttons) can be auto-highlighted when the popup opens
- The last selected/unselected element is highlighted after interaction
- In multiselect mode, the last selected tag is highlighted when the popup opens

This behavior now matches the UX of other UI kits such as [Material UI](https://mui.com/material-ui/react-select/#multiple-select), providing a more consistent and predictable experience

https://github.com/user-attachments/assets/804313cb-791c-4978-8bb0-7e675b323647

