### PR TITLE
RG-2587 - remove excess data-test attr in the Loader

### DIFF
--- a/src/loader/loader.tsx
+++ b/src/loader/loader.tsx
@@ -1,7 +1,5 @@
 import {HTMLAttributes, PureComponent} from 'react';
 
-import dataTests from '../global/data-tests';
-
 import LoaderCore, {LoaderCoreProps} from './loader__core';
 
 export interface LoaderProps extends Partial<LoaderCoreProps>, HTMLAttributes<HTMLElement> {
@@ -39,6 +37,6 @@ export default class Loader extends PureComponent<LoaderProps> {
   render() {
     const {message, size, colors, 'data-test': dataTest, stop, deterministic, ...restProps} = this.props;
 
-    return <div data-test={dataTests('ring-loader', dataTest)} {...restProps} ref={this.initLoader} />;
+    return <div {...restProps} ref={this.initLoader} />;
   }
 }


### PR DESCRIPTION
Now only canvas and loader text have data-test attributes

<img width="518" alt="Screenshot 2025-06-21 at 3 15 49 PM" src="https://github.com/user-attachments/assets/3dbc7985-362d-439d-8625-c8412e04da84" />
