### PR TITLE
RG-2599 exclude Dialog from autodocs

### DIFF
--- a/src/dialog/dialog.stories.tsx
+++ b/src/dialog/dialog.stories.tsx
@@ -15,7 +15,7 @@ import Dialog from './dialog';
 
 export default {
   title: 'Components/Dialog',
-
+  tags: ['!autodocs'],
   parameters: {
     notes: 'The Dialog component is a simple way to present content above an enclosing view.',
     screenshots: {captureSelector: '*[data-test~=ring-dialog]'},

--- a/src/error-bubble/error-bubble.stories.tsx
+++ b/src/error-bubble/error-bubble.stories.tsx
@@ -96,7 +96,7 @@ export const inDialogForm = () => {
 };
 
 inDialogForm.storyName = 'in dialog form';
-
+inDialogForm.tags = ['!autodocs'];
 inDialogForm.parameters = {
   screenshots: {captureSelector: ['*[data-test~=ring-dialog]', '*[data-test~=ring-error-bubble]']},
   a11y: {context: '#storybook-root,*[data-test~=ring-dialog],*[data-test~=ring-error-bubble]'},


### PR DESCRIPTION
Now in Dialog and ErrorBubbles storyes with Dialog hide other stories

It's more convenient to interact with the Dialog component through separate stories
So it looks like the easiest solution is to exclude Dialog from autodocs

An example in the Dialog component 

https://github.com/user-attachments/assets/f3e47dcf-495b-498b-b3fa-72140239bf44

