### PR TITLE
Hide Tooltip if title prop changes to null or undefined

### DIFF
--- a/src/tooltip/tooltip.test.tsx
+++ b/src/tooltip/tooltip.test.tsx
@@ -114,6 +114,23 @@ describe('Tooltip', () => {
       expect(removeEventListener).toHaveBeenCalledTimes(2);
     });
 
+    it('should not render popup when title changes to empty value', () => {
+      const {rerender} = renderTooltip();
+      const tooltipElement = screen.getByRole('tooltip');
+
+      if (!tooltipElement) throw new Error('Tooltip element not found');
+
+      act(() => {
+        fireEvent.mouseEnter(tooltipElement);
+        vi.advanceTimersByTime(SHORT_DELAY);
+      });
+
+      rerender(<Tooltip {...defaultProps} title="" />);
+
+      // Popup should remain hidden
+      expect(Popup).toHaveBeenLastCalledWith(expect.objectContaining({hidden: true}), undefined);
+    });
+
     it('should render popup on mouseenter', () => {
       renderTooltip();
       const tooltipElement = screen.getByText('test elem').closest('span');

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -56,6 +56,7 @@ export default class Tooltip extends Component<TooltipProps> {
     if (!prevProps.title && this.props.title) {
       this.addListeners();
     } else if (prevProps.title && !this.props.title) {
+      this.hidePopup();
       this.listeners.removeAll();
     }
   }


### PR DESCRIPTION
If the `title` prop changes to an empty value after `Tooltip` has been displayed or scheduled to be displayed, the tooltip should be hidden.

https://github.com/user-attachments/assets/12b986da-3902-4401-8fab-8f718a412596

