### PR TITLE
fix: do not render pager if total is less than page size

### DIFF
--- a/src/pager/pager.tsx
+++ b/src/pager/pager.tsx
@@ -315,10 +315,15 @@ export default class Pager extends PureComponent<PagerProps> {
 
   render() {
     const classes = classNames(style.pager, this.props.className);
+    const shouldRenderPagerContent = this.getTotalPages() > 1 || this.props.openTotal;
+
+    if (!shouldRenderPagerContent && this.props.disablePageSizeSelector) {
+      return null;
+    }
 
     return (
       <div data-test="ring-pager" className={classes}>
-        {this.getTotalPages() > 1 || this.props.openTotal ? this.getPagerContent() : this.getPageSizeSelector()}
+        {shouldRenderPagerContent ? this.getPagerContent() : this.getPageSizeSelector()}
       </div>
     );
   }


### PR DESCRIPTION
If total is less than page size and page selector is disabled, then pager is rendered as an empty div with class names.