### PR TITLE
[RG-2644] Set `<Text>` default size to `M`

### DIFF
--- a/src/data-list/item.tsx
+++ b/src/data-list/item.tsx
@@ -135,7 +135,7 @@ export default class Item<T extends SelectionItem> extends PureComponent<ItemPro
     let moreLessButton;
     if (showMoreLessButton === moreLessButtonStates.MORE || showMoreLessButton === moreLessButtonStates.MORE_LOADING) {
       moreLessButton = (
-        <Text info>
+        <Text info size={Text.Size.S}>
           <Link inherit pseudo onClick={this.onShowMore}>
             {'Show more'}
           </Link>
@@ -146,7 +146,7 @@ export default class Item<T extends SelectionItem> extends PureComponent<ItemPro
       );
     } else if (showMoreLessButton === moreLessButtonStates.LESS) {
       moreLessButton = (
-        <Text info>
+        <Text info size={Text.Size.S}>
           <Link inherit pseudo onClick={this.onShowLess}>
             {'Show less'}
           </Link>

--- a/src/text/text.tsx
+++ b/src/text/text.tsx
@@ -3,7 +3,13 @@ import classNames from 'classnames';
 
 import styles from './text.css';
 
-type TextSize = 's' | 'm' | 'l';
+const TextSizes = {
+  S: 's',
+  M: 'm',
+  L: 'l',
+} as const;
+
+type TextSize = (typeof TextSizes)[keyof typeof TextSizes];
 
 export interface TextProps extends HTMLAttributes<HTMLElement> {
   info?: boolean | null | undefined;
@@ -12,18 +18,16 @@ export interface TextProps extends HTMLAttributes<HTMLElement> {
   bold?: boolean | null | undefined;
 }
 
-const TextSize: Record<string, TextSize> = {
-  S: 's',
-  M: 'm',
-  L: 'l',
-};
-
 /**
  * @name Text
  */
 
 export default class Text extends Component<TextProps> {
-  static Size = TextSize;
+  static defaultProps = {
+    size: TextSizes.M,
+  };
+
+  static Size = TextSizes;
 
   render() {
     const {children, className, info, size, bold, ...restProps} = this.props;


### PR DESCRIPTION
At the moment, the `size` prop of the `Text` component is both optional and doesn't have default value. 

This PR:
1. Sets the default value of the `size` prop to `Text.Sizes.M`
2. Improves type definitions for the `Text` component