### PR TITLE
[RG-2652] Add `:host` selector to all `:root` styles for shadow-root compatibility

### DIFF
--- a/src/button-group/button-group.css
+++ b/src/button-group/button-group.css
@@ -2,7 +2,8 @@
 
 @value button, active, flat from "../button/button.css";
 
-:root {
+:root,
+:host {
   --ring-button-group-default-z-index: 1;
   --ring-button-group-disabled-z-index: 0;
   --ring-button-group-active-z-index: 2;

--- a/src/button/button.css
+++ b/src/button/button.css
@@ -2,7 +2,8 @@
 
 @value glyph from "../icon/icon.css";
 
-:root {
+:root,
+:host {
   --ring-button-focus-border-color: var(--ring-border-hover-color);
   --ring-button-shadow: inset 0 0 0 1px;
   --ring-button-loader-width: calc(var(--ring-unit) * 8);

--- a/src/checkbox/checkbox.css
+++ b/src/checkbox/checkbox.css
@@ -1,6 +1,7 @@
 @import "../global/variables.css";
 
-:root {
+:root,
+:host {
   --ring-checkbox-disabled-check-color: var(--ring-white-text-color);
 }
 

--- a/src/date-picker/date-picker.css
+++ b/src/date-picker/date-picker.css
@@ -4,8 +4,8 @@
 /* ensure styles order */
 @import "../input/input.css";
 
-:root {
-  /* stylelint-disable-next-line color-no-hex */
+:root,
+:host {
   --ring-date-picker-hover-color: var(--ring-border-hover-color);
 }
 

--- a/src/error-bubble/error-bubble.css
+++ b/src/error-bubble/error-bubble.css
@@ -1,6 +1,7 @@
 @import "../global/variables.css";
 
-:root {
+:root,
+:host {
   --ring-error-bubble-background-color: var(--ring-popup-background-color);
 }
 

--- a/src/global/variables.css
+++ b/src/global/variables.css
@@ -1,7 +1,8 @@
 /* stylelint-disable color-no-hex */
 
 .light,
-:root {
+:root,
+:host {
   --ring-unit: 8px;
 
   /* Element */

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -2,7 +2,8 @@
 
 @value link, active from "../link/link.css";
 
-:root {
+:root,
+:host {
   --ring-header-link-color: var(--ring-link-color);
 }
 

--- a/src/input-size/input-size.css
+++ b/src/input-size/input-size.css
@@ -1,6 +1,7 @@
 @import "../global/variables.css";
 
-:root {
+:root,
+:host {
   --ring-input-xs: calc(var(--ring-unit) * 12);
   --ring-input-s: calc(var(--ring-unit) * 12);
   --ring-input-m: calc(var(--ring-unit) * 30);

--- a/src/loader-inline/loader-inline.css
+++ b/src/loader-inline/loader-inline.css
@@ -1,6 +1,7 @@
 @import "../global/variables.css";
 
-:root {
+:root,
+:host {
   /* stylelint-disable-next-line color-no-hex */
   --ring-loader-inline-stops: #ff00eb, #bd3bff, #008eff, #58ba00, #f48700, #ff00eb;
 }

--- a/src/progress-bar/progress-bar.css
+++ b/src/progress-bar/progress-bar.css
@@ -1,6 +1,7 @@
 @import "../global/variables.css";
 
-:root {
+:root,
+:host {
   --ring-progress-bar-background-color: rgba(0, 0, 0, 0.2);
   --ring-progress-bar-line-background-color: rgba(255, 255, 255, 0.6);
 }

--- a/src/tabs/tabs.css
+++ b/src/tabs/tabs.css
@@ -3,7 +3,8 @@
 /* ensure styles order */
 @import "../link/link.css";
 
-:root {
+:root,
+:host {
   --ring-selected-tab-color: var(--ring-text-color);
 }
 

--- a/src/tooltip/tooltip.css
+++ b/src/tooltip/tooltip.css
@@ -1,6 +1,7 @@
 @import "../global/variables.css";
 
-:root {
+:root,
+:host {
   --ring-tooltip-background-color: var(--ring-content-background-color);
   --ring-tooltip-text-color: var(--ring-text-color);
 }


### PR DESCRIPTION
Important note – `:root` doesn't have effect when applied within Shadow DOM.

Please, find the repro project attached below. Just unzip it and follow the instruction in its README file.
[ring-ui-shadow-dom.zip](https://github.com/user-attachments/files/22049771/ring-ui-shadow-dom.zip)
