### PR TITLE
RG-2278 Fixed tab-trap with the `focusBackOnExit` enabled

### DIFF
--- a/packages/screenshots/testplane/chrome/components/tabtrap/basic/basic-dark.png
+++ b/packages/screenshots/testplane/chrome/components/tabtrap/basic/basic-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c88d311783ea4f3e023e217046e08c0f2b3510046159cfc0b01a50eb4256ee87
+size 5394

--- a/packages/screenshots/testplane/chrome/components/tabtrap/basic/basic-light.png
+++ b/packages/screenshots/testplane/chrome/components/tabtrap/basic/basic-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab83293518c117293db33866ffd90ff4b10d42efa28f4c12062a63f81b80170a
+size 5286

--- a/packages/screenshots/testplane/chrome/components/tabtrap/with multiple controls/with multiple controls-dark.png
+++ b/packages/screenshots/testplane/chrome/components/tabtrap/with multiple controls/with multiple controls-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:709bf2c41a18c246f409b32f7237126a0e5517892ee3cce2b91247c950fa40dd
+size 5062

--- a/packages/screenshots/testplane/chrome/components/tabtrap/with multiple controls/with multiple controls-light.png
+++ b/packages/screenshots/testplane/chrome/components/tabtrap/with multiple controls/with multiple controls-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40f1728ff75b2be75000a4fb248e7fd2043f7ac061a032e5315a61afc8b642ff
+size 4975

--- a/packages/screenshots/testplane/firefox/components/tabtrap/basic/basic-dark.png
+++ b/packages/screenshots/testplane/firefox/components/tabtrap/basic/basic-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a139b49c01b280f1842f5b6f1f2adca494b253115b530d6f300b573914a1826c
+size 10480

--- a/packages/screenshots/testplane/firefox/components/tabtrap/basic/basic-light.png
+++ b/packages/screenshots/testplane/firefox/components/tabtrap/basic/basic-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8272d2e324e5a7f3cee12748922a41bb4ec16ab2f62a3dcf1cd115c1a9660a42
+size 10007

--- a/packages/screenshots/testplane/firefox/components/tabtrap/with multiple controls/with multiple controls-dark.png
+++ b/packages/screenshots/testplane/firefox/components/tabtrap/with multiple controls/with multiple controls-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fd1638e34431ea7faae78c3ab20921c3e874f505ecd5b7bb8cd60a982fb58a6
+size 8325

--- a/packages/screenshots/testplane/firefox/components/tabtrap/with multiple controls/with multiple controls-light.png
+++ b/packages/screenshots/testplane/firefox/components/tabtrap/with multiple controls/with multiple controls-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:263734a0a782d04d30fdb907b10bb5767235a04acdeb616b926617d6e2171182
+size 8100

--- a/src/tab-trap/tab-trap.stories.css
+++ b/src/tab-trap/tab-trap.stories.css
@@ -1,16 +1,9 @@
 @import '../global/variables.css';
 
 .withMultipleControls {
-  /* padding: calc(2 * var(--ring-unit)); */
-
   display: flex;
   align-items: flex-start;
   flex-direction: column;
-
-  /* font-family: var(--ring-font-family); */
-  /* font-size: var(--ring-font-size); */
-  /* background-color: var(--ring-content-background-color); */
-  /* color: var(--ring-text-color); */
 }
 
 .dropdownComponent {

--- a/src/tab-trap/tab-trap.stories.css
+++ b/src/tab-trap/tab-trap.stories.css
@@ -1,0 +1,23 @@
+@import '../global/variables.css';
+
+.withMultipleControls {
+  /* padding: calc(2 * var(--ring-unit)); */
+
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+
+  /* font-family: var(--ring-font-family); */
+  /* font-size: var(--ring-font-size); */
+  /* background-color: var(--ring-content-background-color); */
+  /* color: var(--ring-text-color); */
+}
+
+.dropdownComponent {
+  padding: var(--ring-unit);
+}
+
+.popupComponent {
+  padding: var(--ring-unit);
+}
+

--- a/src/tab-trap/tab-trap.stories.tsx
+++ b/src/tab-trap/tab-trap.stories.tsx
@@ -1,5 +1,3 @@
-import {Component} from 'react';
-
 import Input from '../input/input';
 import Button from '../button/button';
 import Link from '../link/link';
@@ -15,38 +13,46 @@ export default {
 
   parameters: {
     notes: 'Disallows tabbing out of a designated area.',
-    screenshots: {skip: true},
   },
 };
 
-export const basic = () => {
-  class TabTrapDemo extends Component {
-    render() {
-      return (
-        <div>
-          <Button>Outside of trap</Button>
+export const Basic = () => {
+  return (
+    <div>
+      <Button>Outside of trap</Button>
 
-          <h4>Trap start</h4>
-          <TabTrap>
-            <Input placeholder='inside trap' autoFocus />
-            <Group>
-              <Button>Test</Button>
-              <Link href='#'>Test link</Link>
-            </Group>
-          </TabTrap>
+      <h4>Trap start</h4>
+      <TabTrap>
+        <Input placeholder='inside trap' autoFocus />
+        <Group>
+          <Button>Test</Button>
+          <Link href='#'>Test link</Link>
+        </Group>
+      </TabTrap>
 
-          <h4>Trap end</h4>
+      <h4>Trap end</h4>
 
-          <Button>Outside of trap</Button>
-        </div>
-      );
-    }
-  }
-
-  return <TabTrapDemo />;
+      <Button>Outside of trap</Button>
+    </div>
+  );
 };
 
-basic.storyName = 'TabTrap';
+Basic.parameters = {
+  screenshots: {
+    actions: [
+      {type: 'click', selector: '[placeholder="inside trap"]'},
+      ...Array.from({length: 5}, () => ({
+        type: 'keys',
+        value: 'Tab',
+      })),
+      {
+        type: 'capture',
+        name: 'light',
+        selector: '[id=storybook-root]',
+      },
+    ],
+  },
+};
 
 export const WithMultipleControls = () => {
   return (
@@ -63,4 +69,21 @@ export const WithMultipleControls = () => {
       <Button>button 4</Button>
     </div>
   );
+};
+
+WithMultipleControls.parameters = {
+  screenshots: {
+    actions: [
+      {type: 'click', selector: '[data-test-ring-dropdown-anchor]'},
+      ...Array.from({length: 3}, () => ({
+        type: 'keys',
+        value: 'Tab',
+      })),
+      {
+        type: 'capture',
+        name: 'light',
+        selector: '[id=storybook-root]',
+      },
+    ],
+  },
 };

--- a/src/tab-trap/tab-trap.stories.tsx
+++ b/src/tab-trap/tab-trap.stories.tsx
@@ -54,8 +54,7 @@ export const WithMultipleControls = () => {
       <Button>button 1</Button>
       <Dropdown anchor='Click me' className={styles.dropdownComponent}>
         <Popup className={styles.popupComponent} trapFocus autoFocusFirst>
-          Hello from Ring UI!&#20;
-          <Button primary>Hello</Button>
+          Hello from Ring UI! <Button primary>Hello</Button>
           <Button>Test</Button>
         </Popup>
       </Dropdown>

--- a/src/tab-trap/tab-trap.stories.tsx
+++ b/src/tab-trap/tab-trap.stories.tsx
@@ -5,6 +5,10 @@ import Button from '../button/button';
 import Link from '../link/link';
 import Group from '../group/group';
 import TabTrap from './tab-trap';
+import Popup from '../popup/popup';
+import Dropdown from '../dropdown/dropdown';
+
+import styles from './tab-trap.stories.css';
 
 export default {
   title: 'Components/TabTrap',
@@ -43,3 +47,21 @@ export const basic = () => {
 };
 
 basic.storyName = 'TabTrap';
+
+export const WithMultipleControls = () => {
+  return (
+    <div className={styles.withMultipleControls}>
+      <Button>button 1</Button>
+      <Dropdown anchor='Click me' className={styles.dropdownComponent}>
+        <Popup className={styles.popupComponent} trapFocus autoFocusFirst>
+          Hello from Ring UI!&#20;
+          <Button primary>Hello</Button>
+          <Button>Test</Button>
+        </Popup>
+      </Dropdown>
+      <Button>button 2</Button>
+      <Button>button 3</Button>
+      <Button>button 4</Button>
+    </div>
+  );
+};

--- a/src/tab-trap/tab-trap.test.tsx
+++ b/src/tab-trap/tab-trap.test.tsx
@@ -1,0 +1,54 @@
+import {render, screen} from '@testing-library/react';
+
+import Input from '../input/input';
+import TabTrap from './tab-trap';
+
+describe('TabTrap', () => {
+  it('should clear focus when TabTrap is removed', () => {
+    const {rerender} = render(
+      <div>
+        <button type='button'>{'Before'}</button>
+        <TabTrap>
+          <Input placeholder='inside trap' autoFocus />
+        </TabTrap>
+        <button type='button'>{'After'}</button>
+      </div>,
+    );
+
+    expect(screen.getByPlaceholderText('inside trap')).to.equal(document.activeElement);
+
+    rerender(
+      <div>
+        <button type='button'>{'Before'}</button>
+        <button type='button'>{'After'}</button>
+      </div>,
+    );
+
+    expect(document.activeElement).to.equal(document.body);
+  });
+
+  it('should restore focus to previously focused element when TabTrap exits with focusBackOnExit', () => {
+    const renderContent = (withTabTrap: boolean) => (
+      <div>
+        <button type='button'>{'Open dropdown'}</button>
+        {withTabTrap ? (
+          <TabTrap focusBackOnExit>
+            <Input placeholder='inside trap' autoFocus />
+          </TabTrap>
+        ) : null}
+      </div>
+    );
+
+    const {rerender} = render(renderContent(false));
+
+    const openDropdownButton = screen.getByRole('button', {name: 'Open dropdown'});
+    openDropdownButton.focus();
+    expect(document.activeElement).to.equal(openDropdownButton);
+
+    rerender(renderContent(true));
+    expect(screen.getByPlaceholderText('inside trap')).to.equal(document.activeElement);
+
+    rerender(renderContent(false));
+    expect(document.activeElement).to.equal(openDropdownButton);
+  });
+});

--- a/src/tab-trap/tab-trap.tsx
+++ b/src/tab-trap/tab-trap.tsx
@@ -48,7 +48,7 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
   const trapButtonNodeRef = useRef<HTMLDivElement | null>(null);
   const previousFocusedNodeRef = useRef<Element | null>(null);
   const trapWithoutFocusRef = useRef<boolean>(false);
-  const mountedRef = useRef(false);
+  const mountedRef = useRef<boolean | undefined>(undefined);
 
   // It's the same approach as in focus-trap-react:
   // https://github.com/focus-trap/focus-trap-react/commit/3b22fca9eebeb883edc89548850fe5a5b9d6d50e
@@ -60,17 +60,17 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
 
   useImperativeHandle(ref, () => ({node: nodeRef.current}), []);
 
-  function restoreFocus() {
+  function restoreFocusIfUnmounted(orElse?: () => unknown) {
     const previousFocusedNode = previousFocusedNodeRef.current;
     if (
       previousFocusedNode instanceof HTMLElement &&
       previousFocusedNode.focus &&
       isNodeInVisiblePartOfPage(previousFocusedNode)
     ) {
-      // This is to prevent the focus from being restored the first time
-      // componentWillUnmount is called in StrictMode.
-      if (!mountedRef.current) {
+      if (mountedRef.current === false) {
         previousFocusedNode.focus({preventScroll: true});
+      } else {
+        orElse?.();
       }
     }
   }
@@ -120,7 +120,7 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
 
     return () => {
       if (focusBackOnClose) {
-        restoreFocus();
+        restoreFocusIfUnmounted();
       }
     };
   }, [autoFocusFirst, trapDisabled, focusBackOnClose, focusFirst]);
@@ -132,7 +132,7 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
     if (focusBackOnExit) {
       const prevFocused = event.nativeEvent.relatedTarget;
       if (prevFocused && nodeRef.current && prevFocused instanceof Element && nodeRef.current.contains(prevFocused)) {
-        restoreFocus();
+        restoreFocusIfUnmounted(focusLast);
       }
     } else {
       focusLast();
@@ -155,6 +155,14 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
     }
 
     focusLast();
+  }
+
+  function restoreFocusOrFocusFirst() {
+    if (focusBackOnExit) {
+      restoreFocusIfUnmounted(focusFirst);
+    } else {
+      focusFirst();
+    }
   }
 
   if (trapDisabled) {
@@ -182,7 +190,7 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
         // It never actually stays focused
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
-        onFocus={focusBackOnExit ? restoreFocus : focusFirst}
+        onFocus={restoreFocusOrFocusFirst}
         data-trap-button
       />
     </div>

--- a/src/tab-trap/tab-trap.tsx
+++ b/src/tab-trap/tab-trap.tsx
@@ -65,13 +65,12 @@ const TabTrap = forwardRef<TabTrap, TabTrapProps>(function TabTrap(
     if (
       previousFocusedNode instanceof HTMLElement &&
       previousFocusedNode.focus &&
-      isNodeInVisiblePartOfPage(previousFocusedNode)
+      isNodeInVisiblePartOfPage(previousFocusedNode) &&
+      mountedRef.current === false
     ) {
-      if (mountedRef.current === false) {
-        previousFocusedNode.focus({preventScroll: true});
-      } else {
-        orElse?.();
-      }
+      previousFocusedNode.focus({preventScroll: true});
+    } else {
+      orElse?.();
     }
   }
 


### PR DESCRIPTION
It seems like `focusBackOnExit` is not completed feature. It's intended to be a collaborative mechanism: it expects that the content unmounts on focus lost, and then restores the focus to the former element. But what happens when the content doesn't unmount?

* Before the fix: nothing happens, focus remains on a hidden `div`.
* After the fix: if the content is not unmounted, the `TabTrap` behaves like it does without `focusBackOnExit`: the first or the last focusable element is focused.