### PR TITLE
RG-2442 Remove `postcss-flexbugs-fixes` plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "memoize-one": "^6.0.0",
         "postcss": "^8.5.8",
         "postcss-calc": "^10.1.1",
-        "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-font-family-system-ui": "^5.0.0",
         "postcss-loader": "^8.2.1",
         "postcss-modules-values-replace": "^4.2.2",
@@ -27859,14 +27858,6 @@
         "postcss": "^8.4"
       }
     },
-    "node_modules/postcss-flexbugs-fixes": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "peerDependencies": {
-        "postcss": "^8.1.4"
-      }
-    },
     "node_modules/postcss-focus-visible": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-11.0.0.tgz",
@@ -55426,11 +55417,6 @@
         "@csstools/utilities": "^3.0.0",
         "postcss-value-parser": "^4.2.0"
       }
-    },
-    "postcss-flexbugs-fixes": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
     },
     "postcss-focus-visible": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -243,7 +243,6 @@
     "memoize-one": "^6.0.0",
     "postcss": "^8.5.8",
     "postcss-calc": "^10.1.1",
-    "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-font-family-system-ui": "^5.0.0",
     "postcss-loader": "^8.2.1",
     "postcss-modules-values-replace": "^4.2.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,7 +10,6 @@ module.exports = () => {
       },
     }),
     require('postcss-font-family-system-ui')({browsers: ['last 2 versions']}),
-    require('postcss-flexbugs-fixes')(),
     require('@jetbrains/postcss-require-hover')(),
     require('postcss-calc')({mediaQueries: true}),
   ];


### PR DESCRIPTION
[postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes/blob/master/index.js) only fixes some bugs affecting Internet Explorer, whereas, according to `npx browserslist`, we don't support this browser anymore.