### PR TITLE
RG-2774 Fix ButtonGroup disabled detection with nested children

### DIFF
--- a/src/button-group/button-group.stories.tsx
+++ b/src/button-group/button-group.stories.tsx
@@ -5,6 +5,7 @@ import helpIcon from '@jetbrains/icons/help';
 import userIcon from '@jetbrains/icons/user';
 
 import Button from '../button/button';
+import Tooltip from '../tooltip/tooltip';
 import {ControlsHeight, ControlsHeightContext} from '../global/controls-height';
 import ButtonGroup, {Caption} from './button-group';
 
@@ -35,10 +36,14 @@ export const buttonGroup = () => (
     </div>
     <div>
       <ButtonGroup>
-        <Button disabled>1st disabled</Button>
-        <Button disabled active>
-          2nd disabled
-        </Button>
+        <Tooltip title='1st disabled'>
+          <Button disabled>1st disabled</Button>
+        </Tooltip>
+        <Tooltip title='2nd disabled'>
+          <Button disabled active>
+            2nd disabled
+          </Button>
+        </Tooltip>
         <Button disabled>3rd disabled</Button>
       </ButtonGroup>
     </div>

--- a/src/button-group/button-group.test.tsx
+++ b/src/button-group/button-group.test.tsx
@@ -1,10 +1,120 @@
 import {render, screen} from '@testing-library/react';
 
+import Button from '../button/button';
 import ButtonGroup from './button-group';
+
+import styles from './button-group.css';
+
+function getGroup() {
+  return screen.getByTestId('ring-button-group');
+}
 
 describe('Button Group', () => {
   it('should create component', () => {
     render(<ButtonGroup />);
-    expect(screen.getByTestId('ring-button-group')).to.exist;
+    expect(getGroup()).to.exist;
+  });
+
+  it('should not apply disabled class when no children', () => {
+    render(<ButtonGroup />);
+    expect(getGroup().className).not.to.include(styles.disabled);
+  });
+
+  it('should apply disabled class for a single disabled child', () => {
+    render(
+      <ButtonGroup>
+        <Button disabled>{'A'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).to.include(styles.disabled);
+  });
+
+  it('should not apply disabled class for a single non-disabled child', () => {
+    render(
+      <ButtonGroup>
+        <Button>{'A'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).not.to.include(styles.disabled);
+  });
+
+  it('should apply disabled class for a single nested disabled child', () => {
+    render(
+      <ButtonGroup>
+        <span>
+          <Button disabled>{'A'}</Button>
+        </span>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).to.include(styles.disabled);
+  });
+
+  it('should apply disabled class when all direct children are disabled', () => {
+    render(
+      <ButtonGroup>
+        <Button disabled>{'A'}</Button>
+        <Button disabled>{'B'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).to.include(styles.disabled);
+  });
+
+  it('should not apply disabled class when some direct children are not disabled', () => {
+    render(
+      <ButtonGroup>
+        <Button disabled>{'A'}</Button>
+        <Button>{'B'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).not.to.include(styles.disabled);
+  });
+
+  it('should apply disabled class when all nested children are disabled', () => {
+    render(
+      <ButtonGroup>
+        <span>
+          <Button disabled>{'A'}</Button>
+        </span>
+        <span>
+          <Button disabled>{'B'}</Button>
+        </span>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).to.include(styles.disabled);
+  });
+
+  it('should apply disabled class with a mix of nested and direct disabled children', () => {
+    render(
+      <ButtonGroup>
+        <span>
+          <Button disabled>{'A'}</Button>
+        </span>
+        <Button disabled>{'B'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).to.include(styles.disabled);
+  });
+
+  it('should apply disabled class when conditional children are falsy and remaining are disabled', () => {
+    const condition = false;
+    render(
+      <ButtonGroup>
+        {condition && <Button>{'A'}</Button>}
+        <Button disabled>{'B'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).to.include(styles.disabled);
+  });
+
+  it('should not apply disabled class when a nested child is not disabled', () => {
+    render(
+      <ButtonGroup>
+        <span>
+          <Button>{'A'}</Button>
+        </span>
+        <Button disabled>{'B'}</Button>
+      </ButtonGroup>,
+    );
+    expect(getGroup().className).not.to.include(styles.disabled);
   });
 });

--- a/src/button-group/button-group.tsx
+++ b/src/button-group/button-group.tsx
@@ -6,8 +6,6 @@ import ControlLabel from '../control-label/control-label';
 import ControlHelp from '../control-help/control-help';
 import Caption from './caption';
 
-import type {ButtonAttrs} from '../button/button';
-
 import styles from './button-group.css';
 
 export interface ButtonGroupProps extends HTMLAttributes<HTMLElement> {
@@ -16,6 +14,20 @@ export interface ButtonGroupProps extends HTMLAttributes<HTMLElement> {
   label?: ReactNode;
   help?: ReactNode;
 }
+
+function allChildrenDisabled(children: ReactNode): boolean {
+  if (!children || typeof children !== 'object') return false;
+  if ('props' in children) {
+    const {props} = children as ReactElement<Record<string, unknown>>;
+    if ('disabled' in props) {
+      return !!props.disabled;
+    }
+    return allChildrenDisabled(props.children as ReactNode);
+  }
+  const real = Children.toArray(children);
+  return real.length > 0 && real.every(allChildrenDisabled);
+}
+
 /**
  * @name Button Group
  */
@@ -23,13 +35,7 @@ export default class ButtonGroup extends PureComponent<ButtonGroupProps> {
   render() {
     const {className, split, 'data-test': dataTest, label, help, ...restProps} = this.props;
     const classes = classNames(split ? styles.split : styles.buttonGroup, className, {
-      [styles.disabled]: Children.toArray(this.props.children).every(
-        child =>
-          !!child &&
-          typeof child === 'object' &&
-          'props' in child &&
-          (child as ReactElement<ButtonAttrs>).props.disabled,
-      ),
+      [styles.disabled]: allChildrenDisabled(this.props.children),
     });
 
     return (


### PR DESCRIPTION
## Summary
- Fix `styles.disabled` condition in `ButtonGroup` to recursively traverse nested children (e.g. buttons wrapped in `<Tooltip>`) when determining whether all buttons are disabled
- Extract `isChildDisabled` helper that checks `disabled` prop on direct button elements and recurses into wrapper elements' children
- Update story to wrap disabled buttons in `<Tooltip>` to demonstrate the fix

Fixes https://youtrack.jetbrains.com/issue/RG-2774

## Test plan
- [x] Verify the "all disabled" story section renders with disabled border styling
- [x] Verify non-disabled groups are unaffected
- [x] Verify empty `ButtonGroup` does not incorrectly get disabled styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)