### PR TITLE
RG-2773 Fix empty row on scroll up in dropdown

### DIFF
--- a/src/list/list.test.tsx
+++ b/src/list/list.test.tsx
@@ -384,4 +384,77 @@ describe('List', () => {
       expect(ref.current!.state.activeItem).to.deep.include({key: 0, label: 'Item 0'});
     });
   });
+
+  describe('should recompute row heights on visibility change', () => {
+    const data = [{key: 0, label: 'Item 0'}];
+
+    it('should mount without IntersectionObserver present', () => {
+      const original = window.IntersectionObserver;
+      // @ts-expect-error testing missing API
+      delete window.IntersectionObserver;
+      try {
+        expect(() => {
+          render(<List data={data} maxHeight={200} />);
+        }).not.toThrow();
+      } finally {
+        window.IntersectionObserver = original;
+      }
+    });
+
+    it('should call recomputeRowHeights on invisible-to-visible transition', () => {
+      let observerCallback!: IntersectionObserverCallback;
+      const mockObserve = vi.fn();
+      vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+          constructor(cb: IntersectionObserverCallback) {
+            observerCallback = cb;
+          }
+
+          observe = mockObserve;
+          disconnect = vi.fn();
+        },
+      );
+
+      const spy = vi.spyOn(VirtualizedList.prototype, 'recomputeRowHeights');
+      render(<List data={data} maxHeight={200} />);
+
+      expect(mockObserve).toHaveBeenCalled();
+
+      act(() => {
+        observerCallback([{isIntersecting: true} as IntersectionObserverEntry], {} as IntersectionObserver);
+      });
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not call recomputeRowHeights when already visible', () => {
+      let observerCallback!: IntersectionObserverCallback;
+      vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+          constructor(cb: IntersectionObserverCallback) {
+            observerCallback = cb;
+          }
+
+          observe = vi.fn();
+          disconnect = vi.fn();
+        },
+      );
+
+      const spy = vi.spyOn(VirtualizedList.prototype, 'recomputeRowHeights');
+      render(<List data={data} maxHeight={200} />);
+
+      act(() => {
+        observerCallback([{isIntersecting: true} as IntersectionObserverEntry], {} as IntersectionObserver);
+      });
+      spy.mockClear();
+
+      act(() => {
+        observerCallback([{isIntersecting: true} as IntersectionObserverEntry], {} as IntersectionObserver);
+      });
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -96,6 +96,9 @@ export interface ListProps<T = unknown> {
   maxHeight?: number | null | undefined;
   activeIndex?: number | null | undefined;
   useMouseUp?: boolean | null | undefined;
+  /**
+   * @deprecated No longer used. Visibility is detected automatically via IntersectionObserver. Will be removed in Ring UI 8.0.
+   */
   visible?: boolean | null | undefined;
   disableMoveOverflow?: boolean | null | undefined;
   compact?: boolean | null | undefined;
@@ -212,6 +215,17 @@ export default class List<T = unknown> extends Component<ListProps<T>, ListState
     if (!this.props.renderOptimization) {
       this.scrollToActive();
     }
+    if (this.container) {
+      this.intersectionObserver = new IntersectionObserver(entries => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && !this.wasVisible && this.virtualizedList) {
+            this.virtualizedList.recomputeRowHeights();
+          }
+          this.wasVisible = entry.isIntersecting;
+        }
+      });
+      this.intersectionObserver.observe(this.container);
+    }
   }
 
   shouldComponentUpdate(nextProps: ListProps<T>, nextState: ListState<T>) {
@@ -247,6 +261,7 @@ export default class List<T = unknown> extends Component<ListProps<T>, ListState
   }
 
   componentWillUnmount() {
+    this.intersectionObserver?.disconnect();
     this.unmounted = true;
   }
 
@@ -264,6 +279,8 @@ export default class List<T = unknown> extends Component<ListProps<T>, ListState
   virtualizedList?: VirtualizedList | null;
   unmounted?: boolean;
   container?: HTMLElement | null;
+  private intersectionObserver?: IntersectionObserver;
+  private wasVisible = false;
 
   // eslint-disable-next-line no-magic-numbers
   private _bufferSize = 10; // keep X items above and below of the visible area

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -215,7 +215,7 @@ export default class List<T = unknown> extends Component<ListProps<T>, ListState
     if (!this.props.renderOptimization) {
       this.scrollToActive();
     }
-    if (this.container) {
+    if (this.props.renderOptimization && this.container && typeof IntersectionObserver !== 'undefined') {
       this.intersectionObserver = new IntersectionObserver(entries => {
         for (const entry of entries) {
           if (entry.isIntersecting && !this.wasVisible && this.virtualizedList) {

--- a/test-helpers/jest-globals.js
+++ b/test-helpers/jest-globals.js
@@ -31,6 +31,7 @@ class Observer {
 }
 
 global.window.ResizeObserver = Observer;
+global.window.IntersectionObserver = Observer;
 
 // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty(window, 'matchMedia', {

--- a/test-helpers/vitest-setup.js
+++ b/test-helpers/vitest-setup.js
@@ -23,6 +23,7 @@ class Observer {
 }
 
 global.window.ResizeObserver = Observer;
+global.window.IntersectionObserver = Observer;
 
 window.HTMLCanvasElement.prototype.getContext = () => null;
 


### PR DESCRIPTION
## Summary
- Use `IntersectionObserver` on the List container to detect invisible→visible transitions and call `recomputeRowHeights()`, fixing stale row height cache from `react-virtualized` that caused a phantom empty row when scrolling up in a dropdown
- Mark the unused `visible` prop as `@deprecated` for removal in Ring UI 8.0

## Test plan
- [x] Run existing list tests (`npx jest src/list/`)
- [x] Run select tests (`npx jest src/select/`)
- [x] Manual: open a dropdown with a long list, scroll down, close, reopen, scroll up — no empty row should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)