### PR TITLE
RG-2776 Use constant data-url for avatars in stories

### DIFF
--- a/packages/screenshots/testplane/chrome/components/select/with avatar and long name/with avatar and long name-dark.png
+++ b/packages/screenshots/testplane/chrome/components/select/with avatar and long name/with avatar and long name-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f07e1f9aede31df71a40aa0dbb8aa59147f62bf850c2faceca31913f675fa36
-size 9868
+oid sha256:4c476e31493840aee6e5a2a91aa413a5cd0b5fe1ec53117ac3b42cc9d1bf77cc
+size 9710

--- a/packages/screenshots/testplane/chrome/components/select/with avatar and long name/with avatar and long name.png
+++ b/packages/screenshots/testplane/chrome/components/select/with avatar and long name/with avatar and long name.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1f1274c07f343fb046d5e0a763dc4a1a44f26c1ec65d216674451b55cfe1109
-size 9693
+oid sha256:be56645faa1728870f1e2edebf19020b24edce542adf992740542e9047cc210c
+size 9546

--- a/packages/screenshots/testplane/chrome/components/select/with avatars/with avatars-dark.png
+++ b/packages/screenshots/testplane/chrome/components/select/with avatars/with avatars-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea95b9f47290addedf001503fd4226d471824782d1915d30aaf9d9c710e52e1f
-size 2284
+oid sha256:7a43b2aa3c30b48f9e29cb173ecd1735d529b075ac6de26a4dd77ad8ab70c88c
+size 2127

--- a/packages/screenshots/testplane/chrome/components/select/with avatars/with avatars.png
+++ b/packages/screenshots/testplane/chrome/components/select/with avatars/with avatars.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:534485f2c6c3502252b315307d1bd6ad7de3d1234687f7a751e01c762601982a
-size 2191
+oid sha256:b9b9805d349bd2550bbd659233c6d297ac88da1352d3fedefa4f84bd63cae393
+size 2076

--- a/packages/screenshots/testplane/firefox/components/select/with avatar and long name/with avatar and long name-dark.png
+++ b/packages/screenshots/testplane/firefox/components/select/with avatar and long name/with avatar and long name-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:211a97b0e7f9f60b6851d2dc1c78e005312fed6c0c7fc66a96c0c74a5874b2aa
-size 16535
+oid sha256:aff82086c109985c9bb5f05f318c7374d7d66efaf60ba4e87eca91d8b43c1942
+size 16378

--- a/packages/screenshots/testplane/firefox/components/select/with avatar and long name/with avatar and long name.png
+++ b/packages/screenshots/testplane/firefox/components/select/with avatar and long name/with avatar and long name.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d7a37f10758b804df998a8b1d5d63e787cf75c03fe9b7b84abc93d4aabec9cc
-size 16160
+oid sha256:19e752975e436bf9b984dbf53b1e126dcd647c694f9a7b546fc957efb4e11791
+size 16015

--- a/packages/screenshots/testplane/firefox/components/select/with avatars/with avatars-dark.png
+++ b/packages/screenshots/testplane/firefox/components/select/with avatars/with avatars-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e04e8673b901cffec6fd90fd674b9726d0870f6067ad4d5792afe3ad15ee3f60
-size 3266
+oid sha256:e1c81be8aa69ad7f2a33404f108afea109a58059947356f2b46164c307775b47
+size 2594

--- a/packages/screenshots/testplane/firefox/components/select/with avatars/with avatars.png
+++ b/packages/screenshots/testplane/firefox/components/select/with avatars/with avatars.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4be7ed9a46e3daa9781c1b88c3ce833813c07ff7a980433e3609a1f691c63c04
-size 2727
+oid sha256:962fbbac2ae2d69a8a1a10d3e7b986eb74df6f17eaa44ed914d061adf6b19e05
+size 2507

--- a/src/select/select.stories.tsx
+++ b/src/select/select.stories.tsx
@@ -25,6 +25,12 @@ import styles from './select.stories.css';
 const FLAG_DE_URL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACEAAAAUCAIAAACMMcMmAAAAKklEQVRIx2NgGAWjgAbAh/aI4S7t0agdI9COzx00Rwz/z9Ecjdox8uwAACkGSkKIaGlAAAAAAElFTkSuQmCC';
 
+const FLAG_RU_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAUCAYAAACaq43EAAAAOUlEQVR42u3TUQ0AIAwD0aIGt5OFBtx0mCBNljsD7+uWXwoEDPwPrvKJwJINDDwLvtqZnSwZGHgU3Kx2NIuI4wdUAAAAAElFTkSuQmCC';
+
+const AVATAR_URL =
+  'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8ZGVmcz4KICAgICAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImdyYWRpZW50IiB4MT0iMCIgeTE9IjAiIHgyPSIwIiB5Mj0iMSI+CiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiNCMzQ1RjEiIG9mZnNldD0iMCIvPgogICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjNjY5REZGIiBvZmZzZXQ9IjEiLz4KICAgICAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPC9kZWZzPgogICAgPGc+CiAgICAgICAgPHJlY3QgZmlsbD0idXJsKCNncmFkaWVudCkiCiAgICAgICAgICAgICAgeD0iMCIgeT0iMCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IgogICAgICAgICAgICAgIHJ4PSIzIiByeT0iMyIvPgogICAgICAgIDx0ZXh0IHg9IjIiIHk9IjEzIgogICAgICAgICAgICAgIGZvbnQtZmFtaWx5PSJBcmlhbCwgSGVsdmV0aWNhLCBzYW5zLXNlcmlmIgogICAgICAgICAgICAgIGZvbnQtc2l6ZT0iMTFweCIKICAgICAgICAgICAgICBmaWxsPSIjRkZGRkZGIj4KICAgICAgICAgICAgPHRzcGFuPkJMPC90c3Bhbj4KICAgICAgICAgICAgPHRzcGFuIHg9IjMiIHk9IjE3Ij5fPC90c3Bhbj4KICAgICAgICA8L3RleHQ+CiAgICA8L2c+Cjwvc3ZnPg==';
+
 const {type, size, directions} = Select.defaultProps;
 export default {
   title: 'Components/Select',
@@ -41,8 +47,6 @@ export const withAFilterAndTags: StoryFn<MultipleSelectAttrs> = args => <Select 
 export const withAvatars: StoryFn<SingleSelectAttrs> = args => <Select {...args} />;
 
 {
-  const avatarUrl = `${hubConfig.serverUri}/api/rest/avatar/default?username=blue`;
-
   const tags = [
     {label: 'One', key: '1', type: 'user', readOnly: true},
     {label: 'Two', key: '2', type: 'user', readOnly: false},
@@ -60,7 +64,7 @@ export const withAvatars: StoryFn<SingleSelectAttrs> = args => <Select {...args}
     {
       label: 'With avatar',
       key: 6,
-      avatar: avatarUrl,
+      avatar: AVATAR_URL,
     },
     {
       label: 'With generated avatar',
@@ -101,7 +105,7 @@ export const WithAvatarAndLongName = () => {
     {
       label: 'John Michael William Alexander Doe Richardson Jr',
       key: 1,
-      avatar: `${hubConfig.serverUri}/api/rest/avatar/default?username=jr`,
+      avatar: AVATAR_URL,
     },
     {label: 'Registered Users', key: 2},
     {label: 'Demo Project Team', key: 3},
@@ -573,13 +577,7 @@ withALargeDatasetAndDisabledScrollToActiveItem.parameters = {
 export const multipleWithADescription: StoryFn<MultipleSelectAttrs> = args => <Select {...args} />;
 
 {
-  const deFlag =
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACEAAAAUCAIAAACMMcMmAAAAKklEQVRIx2NgGAWjgAbAh/aI4S7t0agdI9COzx00Rwz/z9Ecjdox8uwAACkGSkKIaGlAAAAAAElFTkSuQmCC';
-  const ruFlag =
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAUCAYAAACaq43EAAAAOUlEQVR42u3TUQ0AIAwD0aIGt5OFBtx0mCBNljsD7+uWXwoEDPwPrvKJwJINDDwLvtqZnSwZGHgU3Kx2NIuI4wdUAAAAAElFTkSuQmCC';
-  const avatarUrl =
-    'data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8ZGVmcz4KICAgICAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImdyYWRpZW50IiB4MT0iMCIgeTE9IjAiIHgyPSIwIiB5Mj0iMSI+CiAgICAgICAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiNCMzQ1RjEiIG9mZnNldD0iMCIvPgogICAgICAgICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjNjY5REZGIiBvZmZzZXQ9IjEiLz4KICAgICAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPC9kZWZzPgogICAgPGc+CiAgICAgICAgPHJlY3QgZmlsbD0idXJsKCNncmFkaWVudCkiCiAgICAgICAgICAgICAgeD0iMCIgeT0iMCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IgogICAgICAgICAgICAgIHJ4PSIzIiByeT0iMyIvPgogICAgICAgIDx0ZXh0IHg9IjIiIHk9IjEzIgogICAgICAgICAgICAgIGZvbnQtZmFtaWx5PSJBcmlhbCwgSGVsdmV0aWNhLCBzYW5zLXNlcmlmIgogICAgICAgICAgICAgIGZvbnQtc2l6ZT0iMTFweCIKICAgICAgICAgICAgICBmaWxsPSIjRkZGRkZGIj4KICAgICAgICAgICAgPHRzcGFuPkJMPC90c3Bhbj4KICAgICAgICAgICAgPHRzcGFuIHg9IjMiIHk9IjE3Ij5fPC90c3Bhbj4KICAgICAgICA8L3RleHQ+CiAgICA8L2c+Cjwvc3ZnPg==';
-  const icons = [deFlag, ruFlag, undefined];
+  const icons = [FLAG_DE_URL, FLAG_RU_URL, undefined];
 
   const elementsNum = 5;
   const dataset = [...Array(elementsNum)].map((elem, idx) => ({
@@ -587,7 +585,7 @@ export const multipleWithADescription: StoryFn<MultipleSelectAttrs> = args => <S
     key: idx,
     description: `description ${idx}`,
     icon: icons[idx % 3],
-    avatar: idx % 2 ? avatarUrl : null,
+    avatar: idx % 2 ? AVATAR_URL : null,
   }));
 
   multipleWithADescription.args = {


### PR DESCRIPTION
Hub API (e.g. https://hub.jetbrains.com/api/rest/avatar/default?username=jr) is not available anymore. Happily, we already have a data-url with an avatar in our stories, so I just reuse it.