### PR TITLE
Grid, Col, Row: accept external data-test attributes and pass DOM props

### DIFF
--- a/src/grid/col.tsx
+++ b/src/grid/col.tsx
@@ -36,7 +36,7 @@ export interface ColProps extends HTMLAttributes<HTMLDivElement> {
  */
 function getClassNames(props: Omit<ColProps, 'children' | 'className' | 'reverse'>) {
   return Object.entries(props)
-    .filter(([key]) => classMap[key])
+    .filter(([key, value]) => classMap[key] && value != null)
     .map(
       ([key, value]) =>
         (styles as Record<string, string | undefined>)[

--- a/src/grid/col.tsx
+++ b/src/grid/col.tsx
@@ -1,5 +1,7 @@
-import {Component, type ReactNode} from 'react';
+import {Component, type HTMLAttributes} from 'react';
 import classNames from 'classnames';
+
+import dataTests from '../global/data-tests';
 
 import styles from './grid.css';
 
@@ -14,8 +16,8 @@ const classMap: Record<string, string> = {
   lgOffset: 'col-lg-offset',
 };
 
-export interface ColProps {
-  children?: ReactNode;
+export interface ColProps extends HTMLAttributes<HTMLDivElement> {
+  'data-test'?: string | null | undefined;
   xs?: boolean | number | null | undefined;
   sm?: boolean | number | null | undefined;
   md?: boolean | number | null | undefined;
@@ -25,7 +27,6 @@ export interface ColProps {
   mdOffset?: number | null | undefined;
   lgOffset?: number | null | undefined;
   reverse?: boolean | null | undefined;
-  className?: string | null | undefined;
 }
 
 /**
@@ -46,13 +47,32 @@ function getClassNames(props: Omit<ColProps, 'children' | 'className' | 'reverse
 
 export default class Col extends Component<ColProps> {
   render() {
-    const {children, className, reverse, ...restProps} = this.props;
-    const classes = classNames(styles.col, className, getClassNames(restProps), {
-      [styles.reverse]: reverse,
-    });
+    const {
+      children,
+      className,
+      'data-test': dataTest,
+      reverse,
+      xs,
+      sm,
+      md,
+      lg,
+      xsOffset,
+      smOffset,
+      mdOffset,
+      lgOffset,
+      ...restProps
+    } = this.props;
+    const classes = classNames(
+      styles.col,
+      className,
+      getClassNames({xs, sm, md, lg, xsOffset, smOffset, mdOffset, lgOffset}),
+      {
+        [styles.reverse]: reverse,
+      },
+    );
 
     return (
-      <div className={classes} data-test='ring-grid-column'>
+      <div {...restProps} className={classes} data-test={dataTests('ring-grid-column', dataTest)}>
         {children}
       </div>
     );

--- a/src/grid/grid.test.tsx
+++ b/src/grid/grid.test.tsx
@@ -1,14 +1,13 @@
-import {type HTMLAttributes} from 'react';
 import {render, screen} from '@testing-library/react';
 
-import {Col, Grid, Row} from './grid';
+import {Col, Grid, Row, type GridProps} from './grid';
 import {type RowProps} from './row';
 import {type ColProps} from './col';
 
 import styles from './grid.css';
 
 describe('Grid', () => {
-  const renderGrid = (props?: HTMLAttributes<HTMLDivElement>) => render(<Grid {...props} />);
+  const renderGrid = (props?: GridProps) => render(<Grid {...props} />);
 
   it('should create component', () => {
     renderGrid();
@@ -23,6 +22,16 @@ describe('Grid', () => {
   it('should use passed className', () => {
     renderGrid({className: 'test-class'});
     expect(screen.getByTestId('ring-grid')).to.have.class('test-class');
+  });
+
+  it('should merge external data-test with default', () => {
+    renderGrid({'data-test': 'my-grid'});
+    expect(screen.getByTestId('ring-grid my-grid')).to.exist;
+  });
+
+  it('should pass DOM props to div', () => {
+    renderGrid({id: 'grid-id'});
+    expect(screen.getByTestId('ring-grid')).to.have.attr('id', 'grid-id');
   });
 });
 
@@ -53,6 +62,23 @@ describe('Row', () => {
     renderRow({reverse: true});
     expect(screen.getByTestId('ring-grid-row')).to.have.class(styles.reverse);
   });
+
+  it('should merge external data-test with default', () => {
+    renderRow({'data-test': 'my-row'});
+    expect(screen.getByTestId('ring-grid-row my-row')).to.exist;
+  });
+
+  it('should pass DOM props to div', () => {
+    renderRow({id: 'row-id'});
+    expect(screen.getByTestId('ring-grid-row')).to.have.attr('id', 'row-id');
+  });
+
+  it('should not pass row-specific props to DOM', () => {
+    renderRow({center: 'md', start: 'lg'});
+    const el = screen.getByTestId('ring-grid-row');
+    expect(el).to.not.have.attr('center');
+    expect(el).to.not.have.attr('start');
+  });
 });
 
 describe('Col', () => {
@@ -81,5 +107,22 @@ describe('Col', () => {
   it('should convert autosize to appropriate className', () => {
     renderCol({xs: true});
     expect(screen.getByTestId('ring-grid-column')).to.have.class(styles['col-xs']);
+  });
+
+  it('should merge external data-test with default', () => {
+    renderCol({'data-test': 'my-col'});
+    expect(screen.getByTestId('ring-grid-column my-col')).to.exist;
+  });
+
+  it('should pass DOM props to div', () => {
+    renderCol({id: 'col-id'});
+    expect(screen.getByTestId('ring-grid-column')).to.have.attr('id', 'col-id');
+  });
+
+  it('should not pass col-specific props to DOM', () => {
+    renderCol({xs: 2, xsOffset: 1});
+    const el = screen.getByTestId('ring-grid-column');
+    expect(el).to.not.have.attr('xs');
+    expect(el).to.not.have.attr('xsOffset');
   });
 });

--- a/src/grid/grid.test.tsx
+++ b/src/grid/grid.test.tsx
@@ -109,6 +109,24 @@ describe('Col', () => {
     expect(screen.getByTestId('ring-grid-column')).to.have.class(styles['col-xs']);
   });
 
+  it('should only add classes for provided size props', () => {
+    renderCol({xs: 2});
+    const el = screen.getByTestId('ring-grid-column');
+    expect(el).to.have.class(styles['col-xs-2']);
+    expect(el).to.not.have.class(styles['col-sm']);
+    expect(el).to.not.have.class(styles['col-md']);
+    expect(el).to.not.have.class(styles['col-lg']);
+  });
+
+  it('should not add any size classes when no size props are provided', () => {
+    renderCol();
+    const el = screen.getByTestId('ring-grid-column');
+    expect(el).to.not.have.class(styles['col-xs']);
+    expect(el).to.not.have.class(styles['col-sm']);
+    expect(el).to.not.have.class(styles['col-md']);
+    expect(el).to.not.have.class(styles['col-lg']);
+  });
+
   it('should merge external data-test with default', () => {
     renderCol({'data-test': 'my-col'});
     expect(screen.getByTestId('ring-grid-column my-col')).to.exist;

--- a/src/grid/grid.tsx
+++ b/src/grid/grid.tsx
@@ -1,20 +1,26 @@
 import {Component, type HTMLAttributes} from 'react';
 import classNames from 'classnames';
 
+import dataTests from '../global/data-tests';
+
 import styles from './grid.css';
+
+export interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  'data-test'?: string | null | undefined;
+}
 
 /**
  * @name Grid
  * @deprecated Will be removed in Ring UI 8.0. Use flexbox or another layout library instead.
  */
 
-export class Grid extends Component<HTMLAttributes<HTMLDivElement>> {
+export class Grid extends Component<GridProps> {
   render() {
-    const {children, className, ...restProps} = this.props;
+    const {children, className, 'data-test': dataTest, ...restProps} = this.props;
     const classes = classNames(styles['container-fluid'], className);
 
     return (
-      <div data-test='ring-grid' {...restProps} className={classes}>
+      <div data-test={dataTests('ring-grid', dataTest)} {...restProps} className={classes}>
         {children}
       </div>
     );

--- a/src/grid/row.tsx
+++ b/src/grid/row.tsx
@@ -1,5 +1,7 @@
-import {Component, type ReactNode} from 'react';
+import {Component, type HTMLAttributes} from 'react';
 import classNames from 'classnames';
+
+import dataTests from '../global/data-tests';
 
 import styles from './grid.css';
 
@@ -19,8 +21,8 @@ const modifierKeys = [
 
 type ModifierType = 'xs' | 'sm' | 'md' | 'lg';
 
-export interface RowProps {
-  children?: ReactNode;
+export interface RowProps extends HTMLAttributes<HTMLDivElement> {
+  'data-test'?: string | null | undefined;
   reverse?: boolean | null | undefined;
   start?: ModifierType | null | undefined;
   center?: ModifierType | null | undefined;
@@ -33,7 +35,6 @@ export interface RowProps {
   between?: ModifierType | null | undefined;
   first?: ModifierType | null | undefined;
   last?: ModifierType | null | undefined;
-  className?: string | null | undefined;
 }
 
 /**
@@ -52,14 +53,36 @@ function getModifierClassNames(props: RowProps) {
 
 export default class Row extends Component<RowProps> {
   render() {
-    const {children, className, reverse, ...restProps} = this.props;
+    const {
+      children,
+      className,
+      'data-test': dataTest,
+      reverse,
+      start,
+      center,
+      end,
+      top,
+      middle,
+      baseline,
+      bottom,
+      around,
+      between,
+      first,
+      last,
+      ...restProps
+    } = this.props;
 
-    const classes = classNames(className, styles.row, getModifierClassNames(restProps), {
-      [styles.reverse]: reverse,
-    });
+    const classes = classNames(
+      className,
+      styles.row,
+      getModifierClassNames({start, center, end, top, middle, baseline, bottom, around, between, first, last}),
+      {
+        [styles.reverse]: reverse,
+      },
+    );
 
     return (
-      <div className={classes} data-test='ring-grid-row'>
+      <div {...restProps} className={classes} data-test={dataTests('ring-grid-row', dataTest)}>
         {children}
       </div>
     );


### PR DESCRIPTION
## Summary
- **Grid, Col, Row** now accept external `data-test` props, joined with the default test ID via `dataTests()` (e.g. `<Col data-test="my-col" />` produces `data-test="ring-grid-column my-col"`)
- **Col and Row** props interfaces extend `HTMLAttributes<HTMLDivElement>`, so all standard DOM props (e.g. `id`, `style`, `onClick`) are now passed through to the underlying `<div>`
- Component-specific props (`xs`, `reverse`, `start`, etc.) are destructured separately to avoid leaking them onto the DOM

## Test plan
- [ ] Verify `data-test` attribute merging: `<Grid data-test="x" />` renders `data-test="ring-grid x"`
- [ ] Verify DOM props pass-through on Col/Row: `<Col id="foo" onClick={fn} />` renders with those attributes
- [ ] Verify component-specific props (e.g. `xs`, `reverse`, `start`) still produce correct CSS classes and don't leak to DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)