### PR TITLE
RG-2780 Improve the "Date Picker/Docs" page

### DIFF
--- a/src/date-picker/date-picker.stories.tsx
+++ b/src/date-picker/date-picker.stories.tsx
@@ -48,8 +48,6 @@ export const SingleDate: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleDate.storyName = 'single date';
-
 export const SingleDateAndTime: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('8 January 2018, 9:45');
 
@@ -73,7 +71,7 @@ SingleDateAndTime.parameters = {
   },
 };
 
-SingleDateAndTime.storyName = 'single date and time';
+SingleDateAndTime.storyName = 'Single Date and Time';
 
 export const Range: StoryFn<DatePickerAttrs> = args => {
   const [{from, to}, setRange] = useState<{
@@ -93,8 +91,6 @@ export const Range: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-Range.storyName = 'range';
-
 export const Clearable: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.01.18');
 
@@ -104,8 +100,6 @@ export const Clearable: StoryFn<DatePickerAttrs> = args => {
     </div>
   );
 };
-
-Clearable.storyName = 'clearable';
 
 export const SingleWithMinMax: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.02.18');
@@ -117,7 +111,7 @@ export const SingleWithMinMax: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleWithMinMax.storyName = 'single with min-max dates';
+SingleWithMinMax.storyName = 'Single With Min-Max Dates';
 
 export const SingleWithMin: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.02.18');
@@ -129,7 +123,9 @@ export const SingleWithMin: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleWithMin.storyName = 'single with min date';
+SingleWithMin.storyName = 'Single With Min Date';
+
+SingleWithMin.tags = ['!autodocs'];
 
 export const SingleWithMax: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.02.18');
@@ -141,7 +137,9 @@ export const SingleWithMax: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleWithMax.storyName = 'single with max date';
+SingleWithMax.storyName = 'Single With Max Date';
+
+SingleWithMax.tags = ['!autodocs'];
 
 export const RangeWithMinMax: StoryFn<DatePickerAttrs> = args => {
   const [{from, to}, setRange] = useState<{
@@ -170,7 +168,7 @@ export const RangeWithMinMax: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-RangeWithMinMax.storyName = 'range with min-max dates';
+RangeWithMinMax.storyName = 'Range With Min-Max Dates';
 
 export const RangeWithMin: StoryFn<DatePickerAttrs> = args => {
   const [{from, to}, setRange] = useState<{
@@ -190,7 +188,9 @@ export const RangeWithMin: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-RangeWithMin.storyName = 'range with min date';
+RangeWithMin.storyName = 'Range With Min Date';
+
+RangeWithMin.tags = ['!autodocs'];
 
 export const RangeWithMax: StoryFn<DatePickerAttrs> = args => {
   const [{from, to}, setRange] = useState<{
@@ -210,7 +210,9 @@ export const RangeWithMax: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-RangeWithMax.storyName = 'range with max date';
+RangeWithMax.storyName = 'Range With Max Date';
+
+RangeWithMax.tags = ['!autodocs'];
 
 export const RangeWithCustomPlaceholders: StoryFn<DatePickerAttrs> = args => {
   const [{from, to}, setRange] = useState<{
@@ -240,7 +242,7 @@ export const RangeWithCustomPlaceholders: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-RangeWithCustomPlaceholders.storyName = 'range with customized placeholders';
+RangeWithCustomPlaceholders.storyName = 'Range With Customized Placeholders';
 
 RangeWithCustomPlaceholders.parameters = {
   screenshots: {skip: true},
@@ -264,7 +266,7 @@ RenderInline.parameters = {
   screenshots: {skip: true},
 };
 
-RenderInline.storyName = 'inline';
+RenderInline.storyName = 'Inline';
 
 export const AllSizes = () => {
   const [date, setDate] = useState<Date | string | null | undefined>('8 January 2018, 9:45');
@@ -291,7 +293,6 @@ export const AllSizes = () => {
   );
 };
 
-AllSizes.storyName = 'all sizes';
 AllSizes.parameters = {
   storyStyles: `
 <style>
@@ -318,7 +319,7 @@ export const StartsFromSunday: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-StartsFromSunday.storyName = 'starts on Sunday';
+StartsFromSunday.storyName = 'Starts on Sunday';
 
 export const SingleDateScrollMonthsTest: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.01.18');
@@ -330,7 +331,7 @@ export const SingleDateScrollMonthsTest: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleDateScrollMonthsTest.storyName = 'single date (scroll months test)';
+SingleDateScrollMonthsTest.storyName = 'Single Date (scroll months test)';
 
 const monthsScrollerSelector = '[data-test="ring-date-popup--months"]';
 
@@ -350,6 +351,8 @@ SingleDateScrollMonthsTest.parameters = {
   },
 };
 
+SingleDateScrollMonthsTest.tags = ['!autodocs'];
+
 export const SingleDateMonthClickTest: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.01.18');
 
@@ -360,7 +363,7 @@ export const SingleDateMonthClickTest: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleDateMonthClickTest.storyName = 'single date (month click test)';
+SingleDateMonthClickTest.storyName = 'Single Date (month click test)';
 
 const octoberSelector = '[data-test="ring-date-popup--month-names"] > button:nth-child(10)';
 
@@ -380,6 +383,8 @@ SingleDateMonthClickTest.parameters = {
   },
 };
 
+SingleDateMonthClickTest.tags = ['!autodocs'];
+
 export const SingleDateScrollYearsTest: StoryFn<DatePickerAttrs> = args => {
   const [date, setDate] = useState<Date | string | null | undefined>('01.01.18');
 
@@ -390,7 +395,7 @@ export const SingleDateScrollYearsTest: StoryFn<DatePickerAttrs> = args => {
   );
 };
 
-SingleDateScrollYearsTest.storyName = 'single date (scroll years test)';
+SingleDateScrollYearsTest.storyName = 'Single Date (scroll years test)';
 
 const yearsScrollerSelector = '[data-test="ring-date-popup--years"]';
 
@@ -409,3 +414,5 @@ SingleDateScrollYearsTest.parameters = {
     ],
   },
 };
+
+SingleDateScrollYearsTest.tags = ['!autodocs'];

--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -68,11 +68,29 @@ export interface DatePickerTranslations extends Partial<DateInputTranslations> {
 }
 
 export type DatePickerProps = Omit<DatePopupProps, 'translations' | 'parseDateInput' | 'onComplete' | 'hidden'> & {
+  /**
+   * Class name added to the root element of the control that activates the popup.
+   */
   className: string;
+  /**
+   * Adds a "Clear" button to the popup, which resets `date` (or `from` and `to`) to `null` when clicked.
+   */
   clear: boolean;
+  /**
+   * Displays the popup trigger as text, similar to a link, instead of a button.
+   */
   inline: boolean;
+  /**
+   * Class name added to the root element of the popup.
+   */
   popupClassName?: string | null | undefined;
+  /**
+   * Additional props for the Dropdown component. See **Components/Dropdown**.
+   */
   dropdownProps?: Partial<DropdownAttrs>;
+  /**
+   * Object with custom popup text values.
+   */
   translations?: DatePickerTranslations | null | undefined;
   displayMonthFormat: (date: Date, locale: Locale | undefined) => string;
   displayDayFormat: (date: Date, locale: Locale | undefined) => string;
@@ -83,14 +101,42 @@ export type DatePickerProps = Omit<DatePopupProps, 'translations' | 'parseDateIn
   rangePlaceholder?: string;
   disabled?: boolean | null | undefined;
   parseDateInput: (input: string | null | undefined) => Date | null;
+  /**
+   * Horizontal size of the popup trigger control. Only applies when `inline` is `false`.
+   */
   size?: Size;
   buttonAttributes?: Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'>;
 };
 
 /**
- * @name Date Picker
+ * Date Picker lets users select a date, a date and time, or a date range.
+ * In the simplest mode, with a single unbounded date, the component needs only two props:
+ *
+ * - `date` to set the current date, and
+ * - `onChange` to be invoked when the user selects the date.
+ *
+ * To limit the selected date, use one or both of the following props:
+ *
+ * - `minDate`
+ * - `maxDate`
+ *
+ * To enable time input, use the `withTime` prop.
+ *
+ * To enable range selection, use the `range` prop. In this mode, use the following props
+ * instead of `date`:
+ *
+ * - `from`
+ * - `to`
+ *
+ * By default, the control that activates the popup is rendered as a button. If you want
+ * text instead, similar to a link, use the `inline` prop.
+ *
+ * The component supports internationalization. For example, in the `en-US` locale,
+ * the calendar starts on Sunday.
+ *
+ * There are also multiple ways to provide custom text and placeholders. See the props
+ * interfaces for details.
  */
-
 export default class DatePicker extends PureComponent<DatePickerProps> {
   static defaultProps: DatePickerProps = {
     className: '',


### PR DESCRIPTION
As a continuation of [RG-2543](https://youtrack.jetbrains.com/issue/RG-2543/), this change improves the [Date Picker/Docs](https://jetbrains.github.io/ring-ui/master/?path=/docs/components-date-picker--docs) page. The goal is to make the “Docs” a reasonable “Getting Started” guide for using the component, with a brief introduction, an API table, and a selection of the most illustrative stories. It should remain concise and easy to read.

Changes:

* Added TS docs for the component (covering the main use cases) and for the essential props. This adds the component description after the title on the “Docs” page, and the props documentation in the API table below.
* Reduced the list of stories displayed in the Docs page. All stories are still available in the expandable list to the left of the page.
* Capitalized story names.

What is still delayed:

* The API table generated automatically by Storybook has several issues. For example, there is no way to control the prop order, some items are missing documentation, and complex types (`object` or `union`) are not expanded. Unfortunately, there is [no easy fix](https://youtrack.jetbrains.com/issue/RG-2780/Improve-the-documentation#focus=Comments-27-13748029.0-0) for this, so this PR does not attempt to substantially improve the table and instead focuses on the rest.