### PR TITLE
Checkbox: compose data-test on label with a passed containerDataTest

### DIFF
--- a/src/checkbox/checkbox.test.tsx
+++ b/src/checkbox/checkbox.test.tsx
@@ -78,4 +78,18 @@ describe('Checkbox', () => {
     fireEvent.change(checkbox, eventMock);
     expect(checkbox.value).to.equal('on');
   });
+
+  it('should render default data-test on the label when no containerDataTest is passed', () => {
+    const checkbox = renderCheckbox();
+    const label = checkbox.closest('label');
+
+    expect(label).to.have.attribute('data-test', 'ring-checkbox');
+  });
+
+  it('should compose containerDataTest with the default data-test on the label', () => {
+    const checkbox = renderCheckbox({containerDataTest: 'my-cb'});
+    const label = checkbox.closest('label');
+
+    expect(label).to.have.attribute('data-test', 'ring-checkbox my-cb');
+  });
 });

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -6,6 +6,7 @@ import minusIcon from '@jetbrains/icons/remove-12px';
 import Icon from '../icon/icon';
 import {createComposedRef} from '../global/compose-refs';
 import ControlHelp from '../control-help/control-help';
+import dataTests from '../global/data-tests';
 
 import styles from './checkbox.css';
 
@@ -18,6 +19,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   indeterminate: boolean;
   inputRef?: Ref<HTMLInputElement>;
   help?: ReactNode;
+  containerDataTest?: string | null | undefined;
 }
 
 /**
@@ -67,6 +69,7 @@ export default class Checkbox extends PureComponent<CheckboxProps> {
       indeterminate,
       inputRef,
       help,
+      containerDataTest,
       ...restProps
     } = this.props;
 
@@ -76,7 +79,11 @@ export default class Checkbox extends PureComponent<CheckboxProps> {
     const labelClasses = classNames(styles.label, labelClassName);
 
     return (
-      <label className={containerClasses} style={containerStyle} data-test='ring-checkbox'>
+      <label
+        className={containerClasses}
+        style={containerStyle}
+        data-test={dataTests('ring-checkbox', containerDataTest)}
+      >
         <input
           {...restProps}
           data-checked={restProps.checked}


### PR DESCRIPTION
## Summary
- Add `containerDataTest` prop to `Checkbox` so consumers can append a custom `data-test` token to the container `<label>`.
- Compose it with the existing `'ring-checkbox'` identifier using `dataTests` (same pattern as `Toggle`, `Dropdown`, etc.), so the default behavior is unchanged when the prop is omitted.

## Test plan
- [ ] `Checkbox` with no `containerDataTest` still renders `data-test="ring-checkbox"` on the `<label>`.
- [ ] `Checkbox containerDataTest="my-cb"` renders `data-test="ring-checkbox my-cb"` on the `<label>`.
- [ ] Existing checkbox tests still pass (`src/checkbox/checkbox.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)