### PR TITLE
RadioItem: compose data-test on label with a passed containerDataTest

### DIFF
--- a/src/radio/radio-item.test.tsx
+++ b/src/radio/radio-item.test.tsx
@@ -1,17 +1,16 @@
-import {type InputHTMLAttributes} from 'react';
 import {screen, render, fireEvent} from '@testing-library/react';
 
-import {RadioItemInner} from './radio-item';
+import {RadioItemInner, type RadioItemInnerProps} from './radio-item';
 
 describe('Radio Item', () => {
   function noop() {}
 
-  const factory = (props?: InputHTMLAttributes<HTMLInputElement>) => (
+  const factory = (props?: RadioItemInnerProps) => (
     <RadioItemInner checked={false} onChange={noop} value='test' {...props}>
       {'test'}
     </RadioItemInner>
   );
-  const renderRadioItem = (props?: InputHTMLAttributes<HTMLInputElement>) => {
+  const renderRadioItem = (props?: RadioItemInnerProps) => {
     render(factory(props));
     return screen.getAllByRole<HTMLInputElement>('radio')[0];
   };
@@ -85,5 +84,19 @@ describe('Radio Item', () => {
     renderRadioItem();
 
     expect(screen.getByRole('radio', {name: 'test'})).to.exist;
+  });
+
+  it('should render default data-test on the label when no containerDataTest is passed', () => {
+    const radioItem = renderRadioItem();
+    const label = radioItem.closest('label');
+
+    expect(label).to.have.attribute('data-test', 'ring-radio-item');
+  });
+
+  it('should compose containerDataTest with the default data-test on the label', () => {
+    const radioItem = renderRadioItem({containerDataTest: 'my-radio'});
+    const label = radioItem.closest('label');
+
+    expect(label).to.have.attribute('data-test', 'ring-radio-item my-radio');
   });
 });

--- a/src/radio/radio-item.tsx
+++ b/src/radio/radio-item.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 
 import getUID from '../global/get-uid';
 import ControlHelp from '../control-help/control-help';
+import dataTests from '../global/data-tests';
 
 import styles from './radio.css';
 
@@ -15,6 +16,7 @@ export const RadioContext = createContext<RadioProps>({});
 
 export interface RadioItemInnerProps extends InputHTMLAttributes<HTMLInputElement> {
   help?: ReactNode;
+  containerDataTest?: string | null | undefined;
 }
 export class RadioItemInner extends Component<RadioItemInnerProps> {
   uid = getUID('ring-radio-item-');
@@ -30,12 +32,17 @@ export class RadioItemInner extends Component<RadioItemInnerProps> {
   };
 
   render() {
-    const {className, children, help, ...restProps} = this.props;
+    const {className, children, help, containerDataTest, ...restProps} = this.props;
 
     const classes = classNames(styles.radio, className);
 
     return (
-      <label ref={this.labelRef} className={classes} htmlFor={this.uid}>
+      <label
+        ref={this.labelRef}
+        className={classes}
+        htmlFor={this.uid}
+        data-test={dataTests('ring-radio-item', containerDataTest)}
+      >
         <input id={this.uid} {...restProps} ref={this.inputRef} className={styles.input} type='radio' />
         <span className={styles.circle} />
         <span className={styles.label}>


### PR DESCRIPTION
## Summary
- Add `containerDataTest` prop to `RadioItemInner` so consumers can append a custom `data-test` token to the container `<label>`.
- Compose it with a `'ring-radio-item'` identifier using `dataTests` (same pattern as `Checkbox` in #9285, `Toggle`, `Dropdown`).
- The label previously had no `data-test`; the default is now `data-test="ring-radio-item"`.

## Test plan
- [ ] `RadioItem` with no `containerDataTest` renders `data-test="ring-radio-item"` on the `<label>`.
- [ ] `RadioItem containerDataTest="my-radio"` renders `data-test="ring-radio-item my-radio"` on the `<label>`.
- [ ] Existing radio tests still pass (`src/radio/radio-item.test.tsx`, `src/radio/radio.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)