### PR TITLE
Tabs: support tabContainerDataTest [publish]

### DIFF
--- a/src/tabs/dumb-tabs.tsx
+++ b/src/tabs/dumb-tabs.tsx
@@ -22,6 +22,7 @@ export interface TabsProps extends Omit<CollapsibleTabsProps, 'onSelect' | 'chil
   onLastVisibleIndexChange?: ((index: number) => void) | null | undefined;
   className?: string | null | undefined;
   tabContainerClassName?: string | null | undefined;
+  tabContainerDataTest?: string | null | undefined;
   titleContainerClassName?: string | null | undefined;
   autoCollapse?: boolean | null | undefined;
   'data-test'?: string | null | undefined;
@@ -71,6 +72,7 @@ class Tabs extends PureComponent<TabsProps> {
     const {
       className,
       tabContainerClassName,
+      tabContainerDataTest,
       titleContainerClassName,
       children,
       selected,
@@ -95,7 +97,12 @@ class Tabs extends PureComponent<TabsProps> {
             {childrenArray.map((tab, index) => this.getTabTitle(selectedKey, tab, index))}
           </div>
         )}
-        <div className={classNames(tabContainerClassName)}>{selectedItem}</div>
+        <div
+          className={classNames(tabContainerClassName)}
+          data-test={dataTests('ring-tabs-container', tabContainerDataTest)}
+        >
+          {selectedItem}
+        </div>
       </div>
     );
   }

--- a/src/tabs/tabs.test.tsx
+++ b/src/tabs/tabs.test.tsx
@@ -78,6 +78,16 @@ describe('Tabs', () => {
     expect(screen.getByRole('button', {name: 'Second'})).to.not.have.attribute('data-test-selected', 'true');
   });
 
+  it('should render default data-test on the tab container when no tabContainerDataTest is passed', () => {
+    renderTabs();
+    expect(screen.getByTestId('ring-tabs-container')).to.exist;
+  });
+
+  it('should compose tabContainerDataTest with the default data-test on the tab container', () => {
+    renderTabs({tabContainerDataTest: 'my-tabs'});
+    expect(screen.getByTestId('ring-tabs-container my-tabs')).to.exist;
+  });
+
   it('should skip CustomItem when selecting the fallback tab', () => {
     render(
       <Tabs selected='non-existing-id'>


### PR DESCRIPTION
## Summary
- Add `tabContainerDataTest` prop to `Tabs` (dumb-tabs) for composing a `data-test` attribute on the tab content container
- Defaults to `ring-tabs-container`, composed with the passed value via `dataTests()` — matches the `containerDataTest` pattern from `RadioItem`

## Test plan
- [ ] `npm test src/tabs/tabs.test.tsx` — two new tests cover default and composed `data-test` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)