### PR TITLE
JT-96560 Use single transform for popup positioning

### DIFF
--- a/src/popup/position-css.ts
+++ b/src/popup/position-css.ts
@@ -85,11 +85,8 @@ export const setCSSAnchorPositioning = ({
   if (calculatedMinWidth !== null) {
     popup.style.minWidth = `${calculatedMinWidth}px`;
   }
-  if (top) {
-    popup.style.transform = `translateY(${top}px)`;
-  }
-  if (left) {
-    popup.style.left = `${left}px`;
+  if (top || left) {
+    popup.style.transform = [top && `translateY(${top}px)`, left && `translateX(${left}px)`].filter(Boolean).join(' ');
   }
 
   // When all directions are BOTTOM, the `max-height: 100%` from CSS should stay applied so popup doesn't overflow the anchor RG-2754

--- a/src/popup/position-css.ts
+++ b/src/popup/position-css.ts
@@ -87,6 +87,8 @@ export const setCSSAnchorPositioning = ({
   }
   if (top || left) {
     popup.style.transform = [top && `translateY(${top}px)`, left && `translateX(${left}px)`].filter(Boolean).join(' ');
+  } else {
+    popup.style.removeProperty('transform');
   }
 
   // When all directions are BOTTOM, the `max-height: 100%` from CSS should stay applied so popup doesn't overflow the anchor RG-2754


### PR DESCRIPTION
## Summary
- Replace mixed `style.transform` / `style.left` with a single `transform` combining `translateX` and `translateY`
- Eliminates inconsistency where vertical offset used `transform` but horizontal offset used `left`
