### PR TITLE
RG-2542 Add `develop-8.0-table` branch to Storybook deploy

### DIFF
--- a/.github/workflows/storybook-deploy-all.yml
+++ b/.github/workflows/storybook-deploy-all.yml
@@ -9,7 +9,7 @@ name: Storybook — Rebuild for release branches
 # - To rebuild all versions from scratch
 #
 # How it works:
-# 1. Builds Storybook for each branch (master, release-6.x, develop-8.0) independently
+# 1. Builds Storybook for each branch (master, release-6.x, develop-8.0, develop-8.0-table) independently
 # 2. Combines all builds into a single deployment structure
 # 3. Uploads and deploys to GitHub Pages via Actions Artifacts
 
@@ -64,6 +64,16 @@ jobs:
           cd ..
           mkdir -p deploy-root/develop-8.0
           cp -r develop-8.0/storybook-dist/. deploy-root/develop-8.0/
+
+      - name: Build develop-8.0-table branch
+        run: |
+          git clone --depth 1 --branch develop-8.0-table https://github.com/${{ github.repository }}.git develop-8.0-table
+          cd develop-8.0-table
+          npm ci
+          npm run build-stories
+          cd ..
+          mkdir -p deploy-root/develop-8.0-table
+          cp -r develop-8.0-table/storybook-dist/. deploy-root/develop-8.0-table/
 
       - name: Create root index
         run: |

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -17,6 +17,7 @@ on:
       - release-6.x
       - release-5.1
       - develop-8.0
+      - develop-8.0-table
 
 permissions:
   contents: read


### PR DESCRIPTION
I would like to have the current [Table WIP](https://github.com/JetBrains/ring-ui/pull/9308) on our [GH Pages](https://jetbrains.github.io/ring-ui/) deployment to request the early feedback from the designers.