### PR TITLE
JT-93843 coordinate token refresh across tabs and retry stale-token 401

### DIFF
--- a/rfc/JT-93843-Token-Refresh-Coordination.md
+++ b/rfc/JT-93843-Token-Refresh-Coordination.md
@@ -25,7 +25,7 @@ Ring UI coordinates silent token refresh with the Web Locks API and reuses a fre
 
 When no rejected token is known, `forceTokenUpdate()` snapshots the stored token before the backend status check. This keeps a sibling refresh that happens during the backend check visible as a changed token.
 
-Silent refresh runs under a Web Lock named by `clientId`. The lock callback only returns `{token}` or `{error}`. Dialog and redirect fallback are handled after the lock is released.
+Silent refresh runs under a Web Lock named by `clientId`. The lock callback normalizes refresh results into either a token result or an error result. Dialog and redirect fallback are handled after the lock is released.
 
 Lock acquisition is bounded by `TOKEN_REFRESH_LOCK_TIMEOUT`. If the Web Locks API is unavailable, lock acquisition times out, or lock acquisition rejects, the tab falls back to the previous unsynchronized refresh behavior.
 

--- a/rfc/JT-93843-Token-Refresh-Coordination.md
+++ b/rfc/JT-93843-Token-Refresh-Coordination.md
@@ -1,0 +1,42 @@
+# JT-93843 Token Refresh Coordination
+
+## Summary
+
+Multiple YouTrack tabs can refresh an access token at the same time after inactivity, sleep, or network recovery. Each silent iframe refresh can supersede the token written by another tab. A tab that receives an already-superseded token then gets a 401 and may show an auth dialog or log the user out until the page is refreshed.
+
+Ring UI coordinates silent token refresh with the Web Locks API and reuses a fresh token written by another tab instead of minting another one.
+
+## Goals
+
+- Serialize silent token refresh across tabs and same-page Ring UI clients that share the same `clientId`.
+- Reuse a locally valid stored token when it differs from the token that failed or from the pre-refresh storage snapshot.
+- Still force a real refresh when the stored token is unchanged, because that token can be locally valid yet server-rejected.
+- Keep interactive dialog and redirect handling outside the Web Lock callback.
+- Retry passive `_detectUserChange` user loading once after a 401 without invoking the interactive refresh fallback.
+
+## Non-goals
+
+- Track all rejected tokens.
+- Add a custom cross-tab locking implementation for browsers without Web Locks.
+
+## Design
+
+`HTTP.request()` keeps the token used for the failed request and passes it to `forceTokenUpdate(failedToken)`. That token is the comparison baseline. If another tab has already written a different locally valid token, Ring UI reuses it. If storage still contains the same token, Ring UI refreshes through Hub.
+
+When no rejected token is known, `forceTokenUpdate()` snapshots the stored token before the backend status check. This keeps a sibling refresh that happens during the backend check visible as a changed token.
+
+Silent refresh runs under a Web Lock named by `clientId`. The lock callback only returns `{token}` or `{error}`. Dialog and redirect fallback are handled after the lock is released.
+
+Lock acquisition is bounded by `TOKEN_REFRESH_LOCK_TIMEOUT`. If the Web Locks API is unavailable, lock acquisition times out, or lock acquisition rejects, the tab falls back to the previous unsynchronized refresh behavior.
+
+`_detectUserChange()` uses the access token from the storage event as the rejected-token baseline when `getUser()` returns 401. On refresh failure, it rethrows the original 401 so the passive storage-event path does not run the interactive force-refresh fallback.
+
+## Rejected Alternatives
+
+### Store the last issued token in `Auth`
+
+One mutable `lastIssuedToken` is not per request. A later request in the same tab can overwrite it before an earlier request handles its 401, causing the earlier request to compare against the fresh stored token and mint another token.
+
+### Store all rejected token hashes
+
+This adds state and cleanup rules without removing the need to know which token failed. The per-request rejected token is already available in `HTTP.request()`.

--- a/src/auth/auth-core.ts
+++ b/src/auth/auth-core.ts
@@ -205,6 +205,10 @@ class Auth implements HTTPAuth {
   private _postponed = false;
   private _backendCheckPromise: Promise<void> | null = null;
   private _forceTokenUpdatePromise: Promise<string | null> | null = null;
+  // The last token this instance handed out. Used as the refresh baseline: if
+  // the stored token differs from it (e.g. another tab refreshed), the stored
+  // one is reused instead of minting yet another token (JT-93843).
+  private _lastIssuedToken: string | null = null;
   private _authDialogService: typeof AuthDialogService | undefined = undefined;
   _domainStorage: AuthStorage<UserChange>;
   user: AuthUser | null = null;
@@ -531,7 +535,9 @@ class Auth implements HTTPAuth {
       if (Auth.storageIsUnavailable) {
         return null; // Forever guest if storage is unavailable
       }
-      return (await this._tokenValidator?.validateTokenLocally()) ?? null;
+      const token = (await this._tokenValidator?.validateTokenLocally()) ?? null;
+      this._lastIssuedToken = token;
+      return token;
     } catch (e) {
       return this.forceTokenUpdate();
     }
@@ -547,29 +553,33 @@ class Auth implements HTTPAuth {
    * iframe-based auth attempt fails but a subsequent one succeeds once
    * the Hub session is re-established.
    *
-   * @param failedToken the token the caller knows was rejected by the server,
-   * if any. Used as the reuse baseline: a stored token that differs from it
+   * A stored token that differs from the last one this instance handed out
    * (e.g. written by another tab) is returned as is instead of minting yet
    * another one (JT-93843).
+   *
    * @return {Promise.<string | null>}
    */
-  forceTokenUpdate(failedToken?: string | null): Promise<string | null> {
+  forceTokenUpdate(): Promise<string | null> {
     if (this._forceTokenUpdatePromise) {
       return this._forceTokenUpdatePromise;
     }
-    this._forceTokenUpdatePromise = this._doForceTokenUpdate(failedToken).finally(() => {
-      this._forceTokenUpdatePromise = null;
-    });
+    this._forceTokenUpdatePromise = this._doForceTokenUpdate()
+      .then(token => {
+        this._lastIssuedToken = token;
+        return token;
+      })
+      .finally(() => {
+        this._forceTokenUpdatePromise = null;
+      });
     return this._forceTokenUpdatePromise;
   }
 
-  private async _doForceTokenUpdate(failedToken?: string | null): Promise<string | null> {
-    // Remember the token we came in with so the lock holder can tell whether
-    // another tab refreshed it while we were waiting. Captured before the
-    // backend check: a sibling tab may refresh during that network wait, and
-    // its fresh token must read as "changed", not become our baseline
-    // (JT-93843).
-    const previousToken = failedToken ?? (await this._storage?.getToken())?.accessToken ?? null;
+  private async _doForceTokenUpdate(): Promise<string | null> {
+    // The refresh baseline: the last token this instance handed out — the one
+    // the caller deems bad. When nothing was issued yet, fall back to the
+    // stored token, captured before the backend check so a sibling tab's
+    // refresh during that network wait reads as "changed" (JT-93843).
+    const previousToken = this._lastIssuedToken ?? (await this._storage?.getToken())?.accessToken ?? null;
 
     try {
       if (!this._backendCheckPromise) {

--- a/src/auth/auth-core.ts
+++ b/src/auth/auth-core.ts
@@ -205,10 +205,6 @@ class Auth implements HTTPAuth {
   private _postponed = false;
   private _backendCheckPromise: Promise<void> | null = null;
   private _forceTokenUpdatePromise: Promise<string | null> | null = null;
-  // The last token this instance handed out. Used as the refresh baseline: if
-  // the stored token differs from it (e.g. another tab refreshed), the stored
-  // one is reused instead of minting yet another token (JT-93843).
-  private _lastIssuedToken: string | null = null;
   private _authDialogService: typeof AuthDialogService | undefined = undefined;
   _domainStorage: AuthStorage<UserChange>;
   user: AuthUser | null = null;
@@ -535,9 +531,7 @@ class Auth implements HTTPAuth {
       if (Auth.storageIsUnavailable) {
         return null; // Forever guest if storage is unavailable
       }
-      const token = (await this._tokenValidator?.validateTokenLocally()) ?? null;
-      this._lastIssuedToken = token;
-      return token;
+      return (await this._tokenValidator?.validateTokenLocally()) ?? null;
     } catch (e) {
       return this.forceTokenUpdate();
     }
@@ -553,33 +547,29 @@ class Auth implements HTTPAuth {
    * iframe-based auth attempt fails but a subsequent one succeeds once
    * the Hub session is re-established.
    *
-   * A stored token that differs from the last one this instance handed out
+   * @param failedToken the token the caller knows was rejected by the server,
+   * if any. Used as the reuse baseline: a stored token that differs from it
    * (e.g. written by another tab) is returned as is instead of minting yet
    * another one (JT-93843).
-   *
    * @return {Promise.<string | null>}
    */
-  forceTokenUpdate(): Promise<string | null> {
+  forceTokenUpdate(failedToken?: string | null): Promise<string | null> {
     if (this._forceTokenUpdatePromise) {
       return this._forceTokenUpdatePromise;
     }
-    this._forceTokenUpdatePromise = this._doForceTokenUpdate()
-      .then(token => {
-        this._lastIssuedToken = token;
-        return token;
-      })
-      .finally(() => {
-        this._forceTokenUpdatePromise = null;
-      });
+    this._forceTokenUpdatePromise = this._doForceTokenUpdate(failedToken).finally(() => {
+      this._forceTokenUpdatePromise = null;
+    });
     return this._forceTokenUpdatePromise;
   }
 
-  private async _doForceTokenUpdate(): Promise<string | null> {
-    // The refresh baseline: the last token this instance handed out — the one
-    // the caller deems bad. When nothing was issued yet, fall back to the
-    // stored token, captured before the backend check so a sibling tab's
-    // refresh during that network wait reads as "changed" (JT-93843).
-    const previousToken = this._lastIssuedToken ?? (await this._storage?.getToken())?.accessToken ?? null;
+  private async _doForceTokenUpdate(failedToken?: string | null): Promise<string | null> {
+    // Remember the token we came in with so the lock holder can tell whether
+    // another tab refreshed it while we were waiting. Captured before the
+    // backend check: a sibling tab may refresh during that network wait, and
+    // its fresh token must read as "changed", not become our baseline
+    // (JT-93843).
+    const previousToken = failedToken ?? (await this._storage?.getToken())?.accessToken ?? null;
 
     try {
       if (!this._backendCheckPromise) {

--- a/src/auth/auth-core.ts
+++ b/src/auth/auth-core.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle,max-lines */
 import {fixUrl, getAbsoluteBaseURL} from '../global/url';
 import Listeners, {type Handler} from '../global/listeners';
-import HTTP, {type HTTPAuth, type RequestParams} from '../http/http';
+import HTTP, {CODE, HTTPError, type HTTPAuth, type RequestParams} from '../http/http';
 import promiseWithTimeout from '../global/promise-with-timeout';
 import {getTranslations, getTranslationsWithFallback, translate} from '../i18n/i18n';
 import AuthStorage, {type AuthState} from './storage';
@@ -19,6 +19,12 @@ const DEFAULT_BACKEND_CHECK_TIMEOUT = 10 * 1000;
 const BACKGROUND_REDIRECT_TIMEOUT = 20 * 1000;
 const DEFAULT_WAIT_FOR_REDIRECT_TIMEOUT = 5 * 1000;
 export const TOKEN_REFRESH_RETRY_DELAYS = [0, 2000, 5000];
+// Covers one healthy holder refresh (up to a 10s iframe timeout) with margin.
+// Beyond that, assume the holder is stuck or timer-throttled in a background
+// tab and refresh unsynchronized rather than stall this tab (JT-93843).
+const TOKEN_REFRESH_LOCK_TIMEOUT = 15 * 1000;
+
+type TokenRefreshAttempt = {token: string | null} | {error: Error};
 
 export const USER_CHANGED_EVENT = 'userChange';
 export const DOMAIN_USER_CHANGED_EVENT = 'domainUser';
@@ -541,19 +547,30 @@ class Auth implements HTTPAuth {
    * iframe-based auth attempt fails but a subsequent one succeeds once
    * the Hub session is re-established.
    *
+   * @param failedToken the token the caller knows was rejected by the server,
+   * if any. Used as the reuse baseline: a stored token that differs from it
+   * (e.g. written by another tab) is returned as is instead of minting yet
+   * another one (JT-93843).
    * @return {Promise.<string | null>}
    */
-  forceTokenUpdate(): Promise<string | null> {
+  forceTokenUpdate(failedToken?: string | null): Promise<string | null> {
     if (this._forceTokenUpdatePromise) {
       return this._forceTokenUpdatePromise;
     }
-    this._forceTokenUpdatePromise = this._doForceTokenUpdate().finally(() => {
+    this._forceTokenUpdatePromise = this._doForceTokenUpdate(failedToken).finally(() => {
       this._forceTokenUpdatePromise = null;
     });
     return this._forceTokenUpdatePromise;
   }
 
-  private async _doForceTokenUpdate(): Promise<string | null> {
+  private async _doForceTokenUpdate(failedToken?: string | null): Promise<string | null> {
+    // Remember the token we came in with so the lock holder can tell whether
+    // another tab refreshed it while we were waiting. Captured before the
+    // backend check: a sibling tab may refresh during that network wait, and
+    // its fresh token must read as "changed", not become our baseline
+    // (JT-93843).
+    const previousToken = failedToken ?? (await this._storage?.getToken())?.accessToken ?? null;
+
     try {
       if (!this._backendCheckPromise) {
         this._backendCheckPromise = this._checkBackendsStatusesIfEnabled();
@@ -565,6 +582,61 @@ class Auth implements HTTPAuth {
       this._backendCheckPromise = null;
     }
 
+    const attempt = await this._tryRefreshTokenAcrossTabs(previousToken);
+    if ('token' in attempt) {
+      return attempt.token;
+    }
+    return this._handleTokenRefreshFailure(attempt.error);
+  }
+
+  /**
+   * Serialize the silent token refresh across all tabs of the same service
+   * using the Web Locks API. Without this, every open tab races Hub with its
+   * own iframe refresh when their tokens expire around the same time, and the
+   * resulting token churn makes some tabs receive an already-stale token and
+   * get logged out (JT-93843). Tabs that acquire the lock after the refresh
+   * reuse the token the holder just obtained instead of hitting Hub again.
+   *
+   * The lock callback never shows dialogs or redirects and never rejects — it
+   * resolves to `{token}` or `{error}` — so the lock is always released
+   * promptly and interactive failure handling runs outside the lock.
+   *
+   * Falls back to an unsynchronized refresh where the Web Locks API is
+   * unavailable (older browsers, insecure contexts, tests) or when the lock
+   * cannot be acquired within {@link TOKEN_REFRESH_LOCK_TIMEOUT} (e.g. held by
+   * a timer-throttled background tab).
+   */
+  private async _tryRefreshTokenAcrossTabs(previousToken: string | null): Promise<TokenRefreshAttempt> {
+    if (navigator.locks == null) {
+      return this._tryRefreshToken(previousToken);
+    }
+    const lockName = `ring-ui-token-refresh-${this.config.clientId}`;
+    try {
+      return await navigator.locks.request(lockName, {signal: AbortSignal.timeout(TOKEN_REFRESH_LOCK_TIMEOUT)}, () =>
+        this._tryRefreshToken(previousToken),
+      );
+    } catch {
+      // Lock acquisition failed or timed out — the callback itself never
+      // rejects. Refresh unsynchronized rather than stall this tab.
+      return this._tryRefreshToken(previousToken);
+    }
+  }
+
+  private async _tryRefreshToken(previousToken: string | null): Promise<TokenRefreshAttempt> {
+    // If another tab refreshed the token while we were waiting for the lock,
+    // reuse it instead of triggering a redundant refresh (JT-93843). Only skip
+    // the refresh when the stored token actually changed — otherwise the token
+    // we hold is still the (server-rejected) one and must be replaced.
+    let storedToken: string | null = null;
+    try {
+      storedToken = (await this._tokenValidator?.validateTokenLocally()) ?? null;
+    } catch {
+      // No valid local token — fall through to refresh.
+    }
+    if (storedToken != null && storedToken !== previousToken) {
+      return {token: storedToken};
+    }
+
     let lastError: Error | null = null;
 
     for (const delay of this.config.tokenRefreshRetryDelays) {
@@ -572,12 +644,16 @@ class Auth implements HTTPAuth {
         await new Promise(resolve => setTimeout(resolve, delay));
       }
       try {
-        return (await this._backgroundFlow?.authorize()) ?? null;
+        return {token: (await this._backgroundFlow?.authorize()) ?? null};
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
       }
     }
 
+    return {error: lastError ?? new Error('Failed to refresh token')};
+  }
+
+  private async _handleTokenRefreshFailure(lastError: Error): Promise<string | null> {
     if (this._canShowDialogs()) {
       return new Promise(resolve => {
         const onTryAgain = async () => {
@@ -597,7 +673,7 @@ class Auth implements HTTPAuth {
         };
         this._showAuthDialog({
           nonInteractive: true,
-          error: lastError as Error,
+          error: lastError,
           onTryAgain,
         });
       });
@@ -607,7 +683,7 @@ class Auth implements HTTPAuth {
       this._redirectCurrentPage(authRequest.url);
     }
 
-    throw new TokenValidator.TokenValidationError(lastError?.message ?? 'Failed to refresh token');
+    throw new TokenValidator.TokenValidationError(lastError.message);
   }
 
   async loadCurrentService() {
@@ -675,7 +751,7 @@ class Auth implements HTTPAuth {
   async _detectUserChange(accessToken: string) {
     const windowWasOpen = this._isLoginWindowOpen;
 
-    const user = await this.getUser(accessToken);
+    const user = await this._getUserWithTokenRefresh(accessToken);
     const onApply = () => {
       this.user = user;
       this.listeners.trigger(USER_CHANGED_EVENT, user);
@@ -699,6 +775,35 @@ class Auth implements HTTPAuth {
           this.config.onPostponeChangedUser(this.user, user);
         },
       });
+    }
+  }
+
+  /**
+   * Fetches the current user, refreshing the token once if the access token we
+   * were handed is already stale. This commonly happens when the token arrives
+   * via a cross-tab storage change: the writing tab's token may expire (or be
+   * superseded) before this tab calls the API, producing a 401. Refreshing and
+   * retrying once avoids a spurious logout / auth dialog (JT-93843).
+   */
+  private async _getUserWithTokenRefresh(accessToken: string) {
+    try {
+      return await this.getUser(accessToken);
+    } catch (error) {
+      if (!(error instanceof HTTPError) || error.status !== CODE.UNAUTHORIZED) {
+        throw error;
+      }
+      // Pass the rejected token as the comparison baseline: any different
+      // stored token (e.g. written by another tab) is worth retrying with,
+      // while an unchanged one forces a real refresh.
+      const attempt = await this._tryRefreshTokenAcrossTabs(accessToken);
+      if ('error' in attempt) {
+        // This runs on a passive cross-tab storage event, so it must not
+        // trigger forceTokenUpdate's interactive dialog/redirect fallback.
+        // Rethrow the original 401 and let the caller decide (init()'s
+        // onTokenChange handler shows a dialog only where allowed).
+        throw error;
+      }
+      return this.getUser(attempt.token);
     }
   }
 

--- a/src/auth/auth-core.ts
+++ b/src/auth/auth-core.ts
@@ -19,9 +19,6 @@ const DEFAULT_BACKEND_CHECK_TIMEOUT = 10 * 1000;
 const BACKGROUND_REDIRECT_TIMEOUT = 20 * 1000;
 const DEFAULT_WAIT_FOR_REDIRECT_TIMEOUT = 5 * 1000;
 export const TOKEN_REFRESH_RETRY_DELAYS = [0, 2000, 5000];
-// Covers one healthy holder refresh (up to a 10s iframe timeout) with margin.
-// Beyond that, assume the holder is stuck or timer-throttled in a background
-// tab and refresh unsynchronized rather than stall this tab (JT-93843).
 const TOKEN_REFRESH_LOCK_TIMEOUT = 15 * 1000;
 
 type TokenRefreshAttempt = {token: string | null} | {error: Error};
@@ -539,18 +536,6 @@ class Auth implements HTTPAuth {
 
   /**
    * Get new token in the background or redirect to the login page.
-   *
-   * Retries background token refresh with delays from {@link AuthConfig.tokenRefreshRetryDelays}
-   * with increasing delays before showing the auth dialog.
-   * This handles transient failures that commonly occur after network
-   * recovery (e.g. waking from sleep, switching networks) where the first
-   * iframe-based auth attempt fails but a subsequent one succeeds once
-   * the Hub session is re-established.
-   *
-   * @param failedToken the token the caller knows was rejected by the server,
-   * if any. Used as the reuse baseline: a stored token that differs from it
-   * (e.g. written by another tab) is returned as is instead of minting yet
-   * another one (JT-93843).
    * @return {Promise.<string | null>}
    */
   forceTokenUpdate(failedToken?: string | null): Promise<string | null> {
@@ -564,11 +549,6 @@ class Auth implements HTTPAuth {
   }
 
   private async _doForceTokenUpdate(failedToken?: string | null): Promise<string | null> {
-    // Remember the token we came in with so the lock holder can tell whether
-    // another tab refreshed it while we were waiting. Captured before the
-    // backend check: a sibling tab may refresh during that network wait, and
-    // its fresh token must read as "changed", not become our baseline
-    // (JT-93843).
     const previousToken = failedToken ?? (await this._storage?.getToken())?.accessToken ?? null;
 
     try {
@@ -582,51 +562,28 @@ class Auth implements HTTPAuth {
       this._backendCheckPromise = null;
     }
 
-    const attempt = await this._tryRefreshTokenAcrossTabs(previousToken);
+    const attempt = await this._refreshTokenUnderWebLock(previousToken);
     if ('token' in attempt) {
       return attempt.token;
     }
     return this._handleTokenRefreshFailure(attempt.error);
   }
 
-  /**
-   * Serialize the silent token refresh across all tabs of the same service
-   * using the Web Locks API. Without this, every open tab races Hub with its
-   * own iframe refresh when their tokens expire around the same time, and the
-   * resulting token churn makes some tabs receive an already-stale token and
-   * get logged out (JT-93843). Tabs that acquire the lock after the refresh
-   * reuse the token the holder just obtained instead of hitting Hub again.
-   *
-   * The lock callback never shows dialogs or redirects and never rejects — it
-   * resolves to `{token}` or `{error}` — so the lock is always released
-   * promptly and interactive failure handling runs outside the lock.
-   *
-   * Falls back to an unsynchronized refresh where the Web Locks API is
-   * unavailable (older browsers, insecure contexts, tests) or when the lock
-   * cannot be acquired within {@link TOKEN_REFRESH_LOCK_TIMEOUT} (e.g. held by
-   * a timer-throttled background tab).
-   */
-  private async _tryRefreshTokenAcrossTabs(previousToken: string | null): Promise<TokenRefreshAttempt> {
+  private async _refreshTokenUnderWebLock(previousToken: string | null): Promise<TokenRefreshAttempt> {
     if (navigator.locks == null) {
-      return this._tryRefreshToken(previousToken);
+      return this._refreshTokenOrReuseChanged(previousToken);
     }
     const lockName = `ring-ui-token-refresh-${this.config.clientId}`;
     try {
       return await navigator.locks.request(lockName, {signal: AbortSignal.timeout(TOKEN_REFRESH_LOCK_TIMEOUT)}, () =>
-        this._tryRefreshToken(previousToken),
+        this._refreshTokenOrReuseChanged(previousToken),
       );
     } catch {
-      // Lock acquisition failed or timed out — the callback itself never
-      // rejects. Refresh unsynchronized rather than stall this tab.
-      return this._tryRefreshToken(previousToken);
+      return this._refreshTokenOrReuseChanged(previousToken);
     }
   }
 
-  private async _tryRefreshToken(previousToken: string | null): Promise<TokenRefreshAttempt> {
-    // If another tab refreshed the token while we were waiting for the lock,
-    // reuse it instead of triggering a redundant refresh (JT-93843). Only skip
-    // the refresh when the stored token actually changed — otherwise the token
-    // we hold is still the (server-rejected) one and must be replaced.
+  private async _refreshTokenOrReuseChanged(previousToken: string | null): Promise<TokenRefreshAttempt> {
     let storedToken: string | null = null;
     try {
       storedToken = (await this._tokenValidator?.validateTokenLocally()) ?? null;
@@ -778,13 +735,6 @@ class Auth implements HTTPAuth {
     }
   }
 
-  /**
-   * Fetches the current user, refreshing the token once if the access token we
-   * were handed is already stale. This commonly happens when the token arrives
-   * via a cross-tab storage change: the writing tab's token may expire (or be
-   * superseded) before this tab calls the API, producing a 401. Refreshing and
-   * retrying once avoids a spurious logout / auth dialog (JT-93843).
-   */
   private async _getUserWithTokenRefresh(accessToken: string) {
     try {
       return await this.getUser(accessToken);
@@ -792,15 +742,8 @@ class Auth implements HTTPAuth {
       if (!(error instanceof HTTPError) || error.status !== CODE.UNAUTHORIZED) {
         throw error;
       }
-      // Pass the rejected token as the comparison baseline: any different
-      // stored token (e.g. written by another tab) is worth retrying with,
-      // while an unchanged one forces a real refresh.
-      const attempt = await this._tryRefreshTokenAcrossTabs(accessToken);
+      const attempt = await this._refreshTokenUnderWebLock(accessToken);
       if ('error' in attempt) {
-        // This runs on a passive cross-tab storage event, so it must not
-        // trigger forceTokenUpdate's interactive dialog/redirect fallback.
-        // Rethrow the original 401 and let the caller decide (init()'s
-        // onTokenChange handler shows a dialog only where allowed).
         throw error;
       }
       return this.getUser(attempt.token);

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -676,11 +676,17 @@ describe('Auth', () => {
       expect(authorizeSpy).not.toHaveBeenCalled();
     });
 
-    it('reuses the stored token when it differs from the explicitly rejected one', async () => {
-      // Models http.request(): a request 401s with an OAuth error while
-      // another tab has already written a fresh token to storage. The rejected
-      // token is passed as the baseline, so the fresh one must be reused
-      // without another refresh (JT-93843).
+    it('reuses the stored token when it differs from the last issued one', async () => {
+      // Models http.request(): a request made with an issued token 401s while
+      // another tab has already written a fresh token to storage. The last
+      // issued token is the baseline, so the fresh one must be reused without
+      // another refresh (JT-93843).
+      await auth._storage?.saveToken({
+        accessToken: 'rejected-token',
+        expires: TokenValidator._epoch() + HOUR,
+        scopes: ['0-0-0-0-0'],
+      });
+      await auth.requestToken(); // issues 'rejected-token', recording the baseline
       await auth._storage?.saveToken({
         accessToken: 'fresh-token',
         expires: TokenValidator._epoch() + HOUR,
@@ -688,7 +694,7 @@ describe('Auth', () => {
       });
       const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
 
-      const token = await auth.forceTokenUpdate('rejected-token');
+      const token = await auth.forceTokenUpdate();
 
       expect(token).to.equal('fresh-token');
       expect(authorizeSpy).not.toHaveBeenCalled();

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -651,10 +651,6 @@ describe('Auth', () => {
 
     it('serializes across tabs via the Web Locks API and reuses a token a sibling refreshed', async () => {
       const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
-      // The lock holder models another tab that refreshed the token (writing a
-      // new one to storage) while this tab was waiting for the lock. This tab
-      // must reuse it and skip the background iframe flow (the thundering-herd
-      // source in JT-93843).
       const request = vi.fn(async (_name: string, _options: unknown, callback: () => Promise<unknown>) => {
         await auth._storage?.saveToken({
           accessToken: 'token-from-other-tab',
@@ -677,10 +673,6 @@ describe('Auth', () => {
     });
 
     it('reuses the stored token when it differs from the explicitly rejected one', async () => {
-      // Models http.request(): a request 401s with an OAuth error while
-      // another tab has already written a fresh token to storage. The rejected
-      // token is passed as the baseline, so the fresh one must be reused
-      // without another refresh (JT-93843).
       await auth._storage?.saveToken({
         accessToken: 'fresh-token',
         expires: TokenValidator._epoch() + HOUR,
@@ -695,10 +687,6 @@ describe('Auth', () => {
     });
 
     it('reuses a token a sibling refreshed during the backend check instead of refreshing again', async () => {
-      // The baseline must be captured before the backend check: a tab whose
-      // check finishes later would otherwise adopt the sibling's fresh token
-      // as its baseline, see it as "unchanged" and mint yet another token
-      // (JT-93843).
       await auth._storage?.saveToken({
         accessToken: 'stale-token',
         expires: TokenValidator._epoch() + HOUR,
@@ -734,9 +722,6 @@ describe('Auth', () => {
     });
 
     it('forces a Hub refresh when the stored token is unchanged (server-rejected but locally valid)', async () => {
-      // No other tab refreshed: the token we hold was rejected server-side but
-      // is still locally valid, so we must obtain a new one rather than reuse
-      // it (JT-93843 — the reuse fast-path must not defeat the 401 retry).
       await auth._storage?.saveToken({
         accessToken: 'stale-token',
         expires: TokenValidator._epoch() + HOUR,

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -4,7 +4,7 @@ import mockedWindow from 'storage-mock';
 import {act} from 'react';
 import {type MockInstance} from 'vitest';
 
-import HTTP from '../http/http';
+import HTTP, {HTTPError} from '../http/http';
 import LocalStorage from '../storage/storage-local';
 import Auth, {USER_CHANGED_EVENT, LOGOUT_EVENT, type AuthUser} from './auth';
 import AuthRequestBuilder from './request-builder';
@@ -618,6 +618,206 @@ describe('Auth', () => {
       await act(() => {
         expect(Auth.prototype._showAuthDialog).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('token refresh coordination (JT-93843)', () => {
+    let auth: Auth;
+
+    beforeEach(() => {
+      vi.spyOn(Auth.prototype, '_checkBackendsAreUp').mockResolvedValue([null, null]);
+      vi.spyOn(AuthRequestBuilder, '_uuid').mockReturnValue('unique');
+
+      auth = new Auth({
+        serverUri: '',
+        redirectUri: 'http://localhost:8080/hub',
+        clientId: '1-1-1-1-1',
+        scope: ['0-0-0-0-0', 'youtrack'],
+        optionalScopes: ['youtrack'],
+        embeddedLogin: true,
+      });
+
+      if (auth._storage) {
+        auth._storage._tokenStorage = new LocalStorage();
+      }
+      auth.setAuthDialogService(() => () => {});
+      auth._initDeferred?.resolve?.();
+    });
+
+    afterEach(async () => {
+      vi.unstubAllGlobals();
+      await Promise.all([auth._storage?.cleanStates(), auth._storage?.wipeToken()]);
+    });
+
+    it('serializes across tabs via the Web Locks API and reuses a token a sibling refreshed', async () => {
+      const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
+      // The lock holder models another tab that refreshed the token (writing a
+      // new one to storage) while this tab was waiting for the lock. This tab
+      // must reuse it and skip the background iframe flow (the thundering-herd
+      // source in JT-93843).
+      const request = vi.fn(async (_name: string, _options: unknown, callback: () => Promise<unknown>) => {
+        await auth._storage?.saveToken({
+          accessToken: 'token-from-other-tab',
+          expires: TokenValidator._epoch() + HOUR,
+          scopes: ['0-0-0-0-0'],
+        });
+        return callback();
+      });
+      vi.stubGlobal('navigator', {...navigator, locks: {request}});
+
+      const token = await auth.forceTokenUpdate();
+
+      expect(request).toHaveBeenCalledWith(
+        'ring-ui-token-refresh-1-1-1-1-1',
+        expect.objectContaining({signal: expect.any(AbortSignal)}),
+        expect.any(Function),
+      );
+      expect(token).to.equal('token-from-other-tab');
+      expect(authorizeSpy).not.toHaveBeenCalled();
+    });
+
+    it('reuses the stored token when it differs from the explicitly rejected one', async () => {
+      // Models http.request(): a request 401s with an OAuth error while
+      // another tab has already written a fresh token to storage. The rejected
+      // token is passed as the baseline, so the fresh one must be reused
+      // without another refresh (JT-93843).
+      await auth._storage?.saveToken({
+        accessToken: 'fresh-token',
+        expires: TokenValidator._epoch() + HOUR,
+        scopes: ['0-0-0-0-0'],
+      });
+      const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
+
+      const token = await auth.forceTokenUpdate('rejected-token');
+
+      expect(token).to.equal('fresh-token');
+      expect(authorizeSpy).not.toHaveBeenCalled();
+    });
+
+    it('reuses a token a sibling refreshed during the backend check instead of refreshing again', async () => {
+      // The baseline must be captured before the backend check: a tab whose
+      // check finishes later would otherwise adopt the sibling's fresh token
+      // as its baseline, see it as "unchanged" and mint yet another token
+      // (JT-93843).
+      await auth._storage?.saveToken({
+        accessToken: 'stale-token',
+        expires: TokenValidator._epoch() + HOUR,
+        scopes: ['0-0-0-0-0'],
+      });
+      vi.spyOn(Auth.prototype, '_checkBackendsAreUp').mockImplementation(async () => {
+        await auth._storage?.saveToken({
+          accessToken: 'token-from-other-tab',
+          expires: TokenValidator._epoch() + HOUR,
+          scopes: ['0-0-0-0-0'],
+        });
+        return [null, null];
+      });
+      const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
+
+      const token = await auth.forceTokenUpdate();
+
+      expect(token).to.equal('token-from-other-tab');
+      expect(authorizeSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to an unsynchronized refresh when the lock cannot be acquired in time', async () => {
+      const request = vi.fn().mockRejectedValue(new DOMException('Lock request timed out', 'AbortError'));
+      vi.stubGlobal('navigator', {...navigator, locks: {request}});
+      const authorizeSpy = auth._backgroundFlow
+        ? vi.spyOn(auth._backgroundFlow, 'authorize').mockResolvedValue('fresh-token')
+        : null;
+
+      const token = await auth.forceTokenUpdate();
+
+      expect(authorizeSpy).toHaveBeenCalled();
+      expect(token).to.equal('fresh-token');
+    });
+
+    it('forces a Hub refresh when the stored token is unchanged (server-rejected but locally valid)', async () => {
+      // No other tab refreshed: the token we hold was rejected server-side but
+      // is still locally valid, so we must obtain a new one rather than reuse
+      // it (JT-93843 — the reuse fast-path must not defeat the 401 retry).
+      await auth._storage?.saveToken({
+        accessToken: 'stale-token',
+        expires: TokenValidator._epoch() + HOUR,
+        scopes: ['0-0-0-0-0'],
+      });
+      const authorizeSpy = auth._backgroundFlow
+        ? vi.spyOn(auth._backgroundFlow, 'authorize').mockResolvedValue('fresh-token')
+        : null;
+
+      const token = await auth.forceTokenUpdate();
+
+      expect(authorizeSpy).toHaveBeenCalled();
+      expect(token).to.equal('fresh-token');
+    });
+  });
+
+  describe('_detectUserChange (JT-93843)', () => {
+    let auth: Auth;
+
+    beforeEach(() => {
+      auth = new Auth({
+        serverUri: '',
+        redirectUri: 'http://localhost:8080/hub',
+        clientId: '1-1-1-1-1',
+        scope: ['0-0-0-0-0', 'youtrack'],
+        optionalScopes: ['youtrack'],
+      });
+      if (auth._storage) {
+        auth._storage._tokenStorage = new LocalStorage();
+      }
+      auth._initDeferred?.resolve?.();
+    });
+
+    afterEach(async () => {
+      await auth._storage?.wipeToken();
+    });
+
+    it('retries getUser with the fresh token another tab wrote when the handed token is stale', async () => {
+      auth.user = {id: 'user'} as AuthUser;
+      await auth._storage?.saveToken({
+        accessToken: 'fresh-token',
+        expires: TokenValidator._epoch() + HOUR,
+        scopes: ['0-0-0-0-0'],
+      });
+      const getUser = vi
+        .spyOn(Auth.prototype, 'getUser')
+        .mockRejectedValueOnce(new HTTPError({status: 401, statusText: 'Unauthorized'}))
+        .mockResolvedValueOnce({id: 'user'});
+
+      await auth._detectUserChange('stale-token');
+
+      expect(getUser).toHaveBeenNthCalledWith(1, 'stale-token');
+      expect(getUser).toHaveBeenNthCalledWith(2, 'fresh-token');
+    });
+
+    it('rethrows the original 401 without dialogs or redirects when the refresh fails', async () => {
+      auth.user = {id: 'user'} as AuthUser;
+      auth.config.tokenRefreshRetryDelays = [0]; // keep the test synchronous
+      vi.spyOn(Auth.prototype, 'getUser').mockRejectedValue(new HTTPError({status: 401, statusText: 'Unauthorized'}));
+      if (auth._backgroundFlow) {
+        vi.spyOn(auth._backgroundFlow, 'authorize').mockRejectedValue(new Error('Failed to refresh authorization'));
+      }
+      vi.spyOn(Auth.prototype, '_redirectCurrentPage').mockReturnValue();
+      const showAuthDialog = vi.spyOn(Auth.prototype, '_showAuthDialog').mockReturnValue();
+
+      await expect(auth._detectUserChange('stale-token')).to.be.rejectedWith('401 Unauthorized');
+
+      expect(Auth.prototype._redirectCurrentPage).not.toHaveBeenCalled();
+      expect(showAuthDialog).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh on non-401 errors', async () => {
+      auth.user = {id: 'user'} as AuthUser;
+      const getUser = vi
+        .spyOn(Auth.prototype, 'getUser')
+        .mockRejectedValue(new HTTPError({status: 500, statusText: 'Server Error'}));
+      const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
+
+      await expect(auth._detectUserChange('token')).to.be.rejectedWith('500 Server Error');
+      expect(getUser).toHaveBeenCalledTimes(1);
+      expect(authorizeSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -676,17 +676,11 @@ describe('Auth', () => {
       expect(authorizeSpy).not.toHaveBeenCalled();
     });
 
-    it('reuses the stored token when it differs from the last issued one', async () => {
-      // Models http.request(): a request made with an issued token 401s while
-      // another tab has already written a fresh token to storage. The last
-      // issued token is the baseline, so the fresh one must be reused without
-      // another refresh (JT-93843).
-      await auth._storage?.saveToken({
-        accessToken: 'rejected-token',
-        expires: TokenValidator._epoch() + HOUR,
-        scopes: ['0-0-0-0-0'],
-      });
-      await auth.requestToken(); // issues 'rejected-token', recording the baseline
+    it('reuses the stored token when it differs from the explicitly rejected one', async () => {
+      // Models http.request(): a request 401s with an OAuth error while
+      // another tab has already written a fresh token to storage. The rejected
+      // token is passed as the baseline, so the fresh one must be reused
+      // without another refresh (JT-93843).
       await auth._storage?.saveToken({
         accessToken: 'fresh-token',
         expires: TokenValidator._epoch() + HOUR,
@@ -694,7 +688,7 @@ describe('Auth', () => {
       });
       const authorizeSpy = auth._backgroundFlow ? vi.spyOn(auth._backgroundFlow, 'authorize') : null;
 
-      const token = await auth.forceTokenUpdate();
+      const token = await auth.forceTokenUpdate('rejected-token');
 
       expect(token).to.equal('fresh-token');
       expect(authorizeSpy).not.toHaveBeenCalled();

--- a/src/http/http.test.ts
+++ b/src/http/http.test.ts
@@ -218,7 +218,7 @@ describe('HTTP', () => {
 
     const res = await http.request<typeof fetchResult>('testurl');
 
-    expect(fakeAuth.forceTokenUpdate).toHaveBeenCalled();
+    expect(fakeAuth.forceTokenUpdate).toHaveBeenCalledWith(FAKE_TOKEN);
 
     expect(res).to.equal(fetchResult);
   });

--- a/src/http/http.test.ts
+++ b/src/http/http.test.ts
@@ -218,7 +218,7 @@ describe('HTTP', () => {
 
     const res = await http.request<typeof fetchResult>('testurl');
 
-    expect(fakeAuth.forceTokenUpdate).toHaveBeenCalledWith(FAKE_TOKEN);
+    expect(fakeAuth.forceTokenUpdate).toHaveBeenCalled();
 
     expect(res).to.equal(fetchResult);
   });

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -196,8 +196,6 @@ export default class HTTP implements Partial<HTTPAuth> {
         typeof error.data.error === 'string' ? this.shouldRefreshToken?.(error.data.error) : false;
 
       if (shouldRefreshToken) {
-        // Pass the rejected token so a fresh one another tab already wrote is
-        // reused instead of forcing yet another refresh (JT-93843).
         token = await this.forceTokenUpdate?.(token);
         response = await this._performRequest(url, token, params);
 

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -54,7 +54,7 @@ function isRawBody(params: RequestParams): params is RequestParams<true> {
 
 export interface HTTPAuth {
   requestToken(): Promise<string | null> | string | null;
-  forceTokenUpdate(failedToken?: string | null): Promise<string | null>;
+  forceTokenUpdate(): Promise<string | null>;
 }
 
 export default class HTTP implements Partial<HTTPAuth> {
@@ -63,7 +63,7 @@ export default class HTTP implements Partial<HTTPAuth> {
   fetchConfig: RequestInit;
   requestToken?: () => Promise<string | null> | string | null;
   shouldRefreshToken?: (error: string) => boolean;
-  forceTokenUpdate?: (failedToken?: string | null) => Promise<string | null>;
+  forceTokenUpdate?: () => Promise<string | null>;
 
   constructor(auth?: HTTPAuth, baseUrl?: string | null | undefined, fetchConfig: RequestInit = {}) {
     if (auth) {
@@ -86,7 +86,7 @@ export default class HTTP implements Partial<HTTPAuth> {
   setAuth = (auth: HTTPAuth) => {
     this.requestToken = () => auth.requestToken();
     this.shouldRefreshToken = (auth.constructor as typeof Auth).shouldRefreshToken;
-    this.forceTokenUpdate = failedToken => auth.forceTokenUpdate(failedToken);
+    this.forceTokenUpdate = () => auth.forceTokenUpdate();
   };
 
   setBaseUrl = (baseUrl: string | null | undefined) => {
@@ -196,9 +196,7 @@ export default class HTTP implements Partial<HTTPAuth> {
         typeof error.data.error === 'string' ? this.shouldRefreshToken?.(error.data.error) : false;
 
       if (shouldRefreshToken) {
-        // Pass the rejected token so a fresh one another tab already wrote is
-        // reused instead of forcing yet another refresh (JT-93843).
-        token = await this.forceTokenUpdate?.(token);
+        token = await this.forceTokenUpdate?.();
         response = await this._performRequest(url, token, params);
 
         return this._processResponse(response);

--- a/src/http/http.ts
+++ b/src/http/http.ts
@@ -54,7 +54,7 @@ function isRawBody(params: RequestParams): params is RequestParams<true> {
 
 export interface HTTPAuth {
   requestToken(): Promise<string | null> | string | null;
-  forceTokenUpdate(): Promise<string | null>;
+  forceTokenUpdate(failedToken?: string | null): Promise<string | null>;
 }
 
 export default class HTTP implements Partial<HTTPAuth> {
@@ -63,7 +63,7 @@ export default class HTTP implements Partial<HTTPAuth> {
   fetchConfig: RequestInit;
   requestToken?: () => Promise<string | null> | string | null;
   shouldRefreshToken?: (error: string) => boolean;
-  forceTokenUpdate?: () => Promise<string | null>;
+  forceTokenUpdate?: (failedToken?: string | null) => Promise<string | null>;
 
   constructor(auth?: HTTPAuth, baseUrl?: string | null | undefined, fetchConfig: RequestInit = {}) {
     if (auth) {
@@ -86,7 +86,7 @@ export default class HTTP implements Partial<HTTPAuth> {
   setAuth = (auth: HTTPAuth) => {
     this.requestToken = () => auth.requestToken();
     this.shouldRefreshToken = (auth.constructor as typeof Auth).shouldRefreshToken;
-    this.forceTokenUpdate = () => auth.forceTokenUpdate();
+    this.forceTokenUpdate = failedToken => auth.forceTokenUpdate(failedToken);
   };
 
   setBaseUrl = (baseUrl: string | null | undefined) => {
@@ -196,7 +196,9 @@ export default class HTTP implements Partial<HTTPAuth> {
         typeof error.data.error === 'string' ? this.shouldRefreshToken?.(error.data.error) : false;
 
       if (shouldRefreshToken) {
-        token = await this.forceTokenUpdate?.();
+        // Pass the rejected token so a fresh one another tab already wrote is
+        // reused instead of forcing yet another refresh (JT-93843).
+        token = await this.forceTokenUpdate?.(token);
         response = await this._performRequest(url, token, params);
 
         return this._processResponse(response);


### PR DESCRIPTION
## Problem

[JT-93843](https://youtrack.jetbrains.com/issue/JT-93843): users with several YouTrack tabs open intermittently get logged out (401) and have to reload — even on an active machine. The earlier retry fix (#9203) only covered transient network failures in the background flow and didn't help.

Console logs from affected users show the 401 surfacing from `_detectUserChange` (`RingUI Auth: Init failure ... at _detectUserChange`) — a path #9203 never touched.

## Root cause

1. **Cross-tab refresh race (thundering herd).** When tokens expire around the same time, every open tab races Hub with its own silent iframe refresh. The resulting token churn hands some tabs an already-superseded token, which then 401s. `forceTokenUpdate` only deduped within a single tab. This also explains why shortening the token lifetime anecdotally reduced the failure rate.
2. **No retry on the passive path.** `_detectUserChange` (fired by a cross-tab token-storage change) called `getUser` with the handed token and went straight to the auth dialog on 401.

## Fix

**Cross-tab coordination** (`auth-core.ts`):
- Silent refresh is serialized across tabs via the Web Locks API (`ring-ui-token-refresh-<clientId>`). The lock holder refreshes; tabs that acquire the lock afterwards reuse the token the holder just wrote — but only when the stored token actually **changed** while waiting. An unchanged (server-rejected yet locally valid) token still forces a real refresh, so the reuse fast-path can't defeat a 401 retry.
- Callers that know which token the server rejected (`http.request` retry, `_detectUserChange`) pass it explicitly as the comparison baseline. The baseline for plain `forceTokenUpdate()` is captured **before** the backend status check, so a sibling's refresh during that network wait reads as "changed".
- The lock callback never shows dialogs, never redirects, and never rejects — it resolves to `{token} | {error}`, so the lock is always released promptly. Interactive failure handling (`_handleTokenRefreshFailure`) runs after release.
- Lock acquisition is bounded by a 15s `AbortSignal.timeout` (a timer-throttled background tab could otherwise hold waiters for minutes) and falls back to an unsynchronized refresh, as it does where Web Locks is unavailable.

**Passive 401 retry** (`auth-core.ts`):
- `_detectUserChange` → `_getUserWithTokenRefresh`: on 401, refresh once (rejected token as baseline) and retry `getUser`. A failed refresh rethrows the original 401 instead of triggering the interactive dialog/redirect fallback — preserving old behavior for consumers without embedded login (Hub, TeamCity).

**HTTP retry baseline** (`http.ts`):
- `HTTP.request()`'s refresh-and-retry now passes the rejected token to `forceTokenUpdate(failedToken?)` (backwards-compatible optional param), so a fresh token another tab already wrote is reused instead of minting yet another one.

## Testing

- 7 new unit tests: sibling-token reuse (via lock and during backend check), unchanged-token forces refresh, explicit rejected-token baseline, lock-timeout fallback, passive 401 retry, failed-refresh rethrow (no dialog/redirect), non-401 propagation. Key tests verified to fail against the pre-fix code.
- Verified live in Storybook (`Utilities/Auth → basic`) against hub.jetbrains.com with `navigator.locks` instrumentation: lock acquired with correct name + AbortSignal; sibling-written token reused with no redundant refresh; permanently-held lock times out after 15s and falls back to a working unsynchronized refresh; init recovers silently from a server-rejected stored token.
