### PR TITLE
RG-2790 Make date placeholder fully translatable

### DIFF
--- a/src/date-picker/consts.ts
+++ b/src/date-picker/consts.ts
@@ -96,6 +96,7 @@ export interface DateInputTranslations {
   addSecondDate?: string;
   addTime?: string;
   selectName?: string;
+  selectDate?: string;
 }
 
 export interface DateSpecificPopupProps {

--- a/src/date-picker/date-input.tsx
+++ b/src/date-picker/date-input.tsx
@@ -93,7 +93,7 @@ export default class DateInput extends React.PureComponent<DateInputProps> {
       timePlaceholder,
       locale,
     } = this.props;
-    const {translate} = this.context;
+    const {messages, translate} = this.context;
 
     let displayText = '';
     if (active && hoverDate) {
@@ -117,9 +117,13 @@ export default class DateInput extends React.PureComponent<DateInputProps> {
         default:
           return (
             translations?.selectDate ??
-            translations?.selectName?.replace('%name%', name).replace('{{name}}', name) ??
+            translations?.selectName ??
+            messages.selectDate ??
+            messages.selectName ??
             translate('selectDate')
-          );
+          )
+            .replace('%name%', name)
+            .replace('{{name}}', name);
       }
     })();
 

--- a/src/date-picker/date-input.tsx
+++ b/src/date-picker/date-input.tsx
@@ -115,9 +115,11 @@ export default class DateInput extends React.PureComponent<DateInputProps> {
         case 'time':
           return timePlaceholder || (translations?.addTime ?? translate('addTime'));
         default:
-          return (translations?.selectName ?? translate('selectName'))
-            .replace('%name%', name)
-            .replace('{{name}}', name);
+          return (
+            translations?.selectDate ??
+            translations?.selectName?.replace('%name%', name).replace('{{name}}', name) ??
+            translate('selectDate')
+          );
       }
     })();
 

--- a/src/date-picker/date-picker.test.tsx
+++ b/src/date-picker/date-picker.test.tsx
@@ -62,6 +62,12 @@ describe('Date Picker', () => {
     expect(screen.getByTestId('ring-date-popup')).to.exist;
   });
 
+  it('should use a fully translatable placeholder for a single date', async () => {
+    render(<DatePicker />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByPlaceholderText('Select a date')).to.exist;
+  });
+
   it('should display in the popup the component passed through its render prop', async () => {
     function customComponent() {
       return (

--- a/src/date-picker/date-picker.test.tsx
+++ b/src/date-picker/date-picker.test.tsx
@@ -2,6 +2,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 
+import {I18nContext} from '../i18n/i18n-context';
 import DatePicker from './date-picker';
 import {getDefaultScrollDate} from './consts';
 
@@ -66,6 +67,16 @@ describe('Date Picker', () => {
     render(<DatePicker />);
     await userEvent.click(screen.getByRole('button'));
     expect(screen.getByPlaceholderText('Select a date')).to.exist;
+  });
+
+  it('should use the legacy global selectName translation when selectDate is missing', async () => {
+    render(
+      <I18nContext.Provider value={{messages: {selectName: 'Datum auswählen'}, translate: () => 'Select a date'}}>
+        <DatePicker />
+      </I18nContext.Provider>,
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByPlaceholderText('Datum auswählen')).to.exist;
   });
 
   it('should display in the popup the component passed through its render prop', async () => {

--- a/src/i18n/messages.json
+++ b/src/i18n/messages.json
@@ -19,6 +19,7 @@
   "addSecondDate": "Add second date",
   "addTime": "Add time",
   "selectName": "Select {{name}}",
+  "selectDate": "Select a date",
   "setDate": "Set a date",
   "setDateTime": "Set date and time",
   "setPeriod": "Set a period",


### PR DESCRIPTION
## Summary

- add a complete `Select a date` localization message for the single-date picker input
- keep `selectName` as a compatibility fallback for custom DatePicker translations
- cover the default popup placeholder with a regression test

## Root cause

The DatePicker translated `Select {{name}}` and then interpolated the internal field name `date`. The sentence was localized in YouTrack, but the interpolated noun remained English.


Issue: [RG-2790](https://youtrack.jetbrains.com/issue/RG-2790)