### PR TITLE
RG-2791 Alias imported `active` to prevent its collisions with `:active`

### DIFF
--- a/src/button-group/button-group.css
+++ b/src/button-group/button-group.css
@@ -1,6 +1,6 @@
 @import '../global/variables.css';
 
-@value button, active, flat from '../button/button.css';
+@value button, active as buttonActive, flat from '../button/button.css';
 
 :root,
 :host {
@@ -133,14 +133,14 @@
     0 0 0 1px var(--ring-border-hover-color);
 }
 
-.buttonGroup .button.button.active {
+.buttonGroup .button.button.buttonActive {
   --ring-button-border-radius-left: var(--ring-border-radius);
   --ring-button-border-radius-right: var(--ring-border-radius);
 
   box-shadow: var(--ring-button-shadow) var(--ring-button-border-color);
 }
 
-.buttonGroup .button:focus-visible.active {
+.buttonGroup .button:focus-visible.buttonActive {
   --ring-button-border-radius-left: var(--ring-border-radius);
   --ring-button-border-radius-right: var(--ring-border-radius);
 
@@ -149,7 +149,7 @@
     0 0 0 1px var(--ring-border-hover-color);
 }
 
-.buttonGroup .button.active[disabled] {
+.buttonGroup .button.buttonActive[disabled] {
   box-shadow: var(--ring-button-shadow) var(--ring-border-hover-color);
 }
 /* stylelint-enable */
@@ -240,7 +240,7 @@
     }
   }
 
-  & .active {
+  & .buttonActive {
     z-index: var(--ring-button-group-active-z-index);
 
     &[disabled] {

--- a/src/header/header.css
+++ b/src/header/header.css
@@ -1,6 +1,6 @@
 @import '../global/variables.css';
 
-@value link, active from '../link/link.css';
+@value link, active as linkActive from '../link/link.css';
 
 :root,
 :host {
@@ -41,7 +41,7 @@
     color: var(--ring-header-link-color);
   }
 
-  & .active {
+  & .linkActive {
     color: var(--ring-active-text-color);
   }
 }
@@ -72,7 +72,7 @@
     color: var(--ring-header-link-color);
   }
 
-  & .active {
+  & .linkActive {
     color: var(--ring-active-text-color);
   }
 }


### PR DESCRIPTION
In the prebuilt `style.css`, `:active` pseudo-class is wrongly rewritten to `:ring-button-active` for button groups.

The problem occurs because `button-group.css` [imports](https://github.com/JetBrains/ring-ui/blob/924aee865ccff78aed28a262c1229943bb2381b7/src/button-group/button-group.css#L3) `active` from `button.css`:

```postcss
@value button, active, flat from ../button/button.css;
```

This makes `active` a local imported symbol. In the [CSS Modules: Values](https://github.com/css-modules/postcss-modules-values), symbol replacement is token-based and applies not only to class names, but also to selector and at-rule tokens. As a result, `:active` can be rewritten incorrectly. This is a known behavior limitation; see e.g. css-modules/postcss-modules-values#4.

This PR introduces the workaround, which is simply to import the symbol under an alias:

```postcss
@value button, active as buttonActive ...;
```

and then use that alias instead of `.active` in class selectors. This keeps `:active` untouched.

The same workaround was also applied to `header.css`, which [imports](https://github.com/JetBrains/ring-ui/blob/924aee865ccff78aed28a262c1229943bb2381b7/src/header/header.css#L3) `active` from `link.css`. That file has not shown errors so far, but the alias was added for consistency and to prevent similar collisions in the future.