### PR TITLE
Add keepMounted and headingLevel props to Collapse/CollapsibleGroup

### DIFF
--- a/.teamcity/src/Project.kt
+++ b/.teamcity/src/Project.kt
@@ -18,6 +18,7 @@ object Project : Project({
   buildType(SecurityAudit)
   buildType(UnpublishSpecificVersion)
   buildType(GeminiTests)
+  buildType(React18Compat)
   buildType(QodanaAnalysis)
   buildType(UnitTestsAndBuild)
   buildType(Publish)

--- a/.teamcity/src/tests/AllChecks.kt
+++ b/.teamcity/src/tests/AllChecks.kt
@@ -81,5 +81,8 @@ object AllChecks : BuildType({
     snapshot(ConsoleErrors) {
       onDependencyCancel = FailureAction.ADD_PROBLEM
     }
+    snapshot(React18Compat) {
+      onDependencyCancel = FailureAction.ADD_PROBLEM
+    }
   }
 })

--- a/.teamcity/src/tests/React18Compat.kt
+++ b/.teamcity/src/tests/React18Compat.kt
@@ -1,0 +1,55 @@
+package tests
+
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.DslContext
+import jetbrains.buildServer.configs.kotlin.buildSteps.script
+
+/**
+ * Runs the Collapse/CollapsibleGroup test suites against the React 18 runtime.
+ *
+ * Collapse serializes the `inert` attribute differently for React 18 (empty-string
+ * attribute form) and React 19 (real boolean), and the main test run — pinned to
+ * React 19 — never exercises the React 18 branch even though `react >=18` is a
+ * supported peer range. Runtime only: the repository is type-checked against the
+ * React 19 typings, so no React 18 type packages are involved.
+ *
+ * TODO drop this build in develop-8.0 — Ring UI 8.0 supports React 19 only
+ */
+object React18Compat : BuildType({
+  name = "React 18 runtime compatibility"
+
+  allowExternalStatus = true
+
+  params {
+    param("env.NODE_OPTIONS", "--max-old-space-size=8192")
+  }
+
+  vcs {
+    root(DslContext.settingsRoot)
+  }
+
+  steps {
+    script {
+      name = "Run Collapse tests on React 18"
+      scriptContent = """
+                #!/bin/bash
+                set -e -x
+
+                node -v
+                npm -v
+
+                chown -R root:root . # See https://github.com/npm/cli/issues/4589
+                mkdir -p node_modules
+                npm install
+                npm install --no-save react@18 react-dom@18
+                npx vitest run src/collapse src/collapsible-group
+            """.trimIndent()
+      dockerImage = "registry.jetbrains.team/p/ij/docker-hub/node:22.22.3"
+    }
+  }
+
+  requirements {
+    exists("docker.version")
+    contains("docker.server.osType", "linux")
+  }
+})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [7.0.121]
+- Added `keepMounted` prop to `Collapse` and `CollapsibleGroup` that keeps collapsed content mounted (hidden via `visibility: hidden` and `inert`) instead of unmounting it, preserving local state, subscriptions and iframes. Limitations: content rendered through portals (e.g. `Popup`) is not hidden, and hidden form controls still participate in form validation — disable them while collapsed if needed.
+- Added `headingLevel` prop to `CollapsibleGroup` that wraps the header in an `<h2>`–`<h6>` element to preserve the document outline.
+- Fixed `Collapse` with `disableAnimation`: a positive `minHeight` preview now stays rendered while collapsed, and turning `disableAnimation` off while collapsed no longer re-renders hidden content into the tab order.
+- `CollapseContent` is now `inert` whenever the panel is collapsed, matching `aria-expanded`: a `minHeight` preview stays visible but is no longer interactive, and content clipped below it can no longer take keyboard focus.
+
 ## [7.0.118]
 - Updated Alert styles to match Figma design
 - Added `Alert.Type.INFO` alert type with an info-filled icon, and a matching `alertService.infoMessage()` helper

--- a/packages/screenshots/testplane/chrome/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics-dark.png
+++ b/packages/screenshots/testplane/chrome/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0958cd882c4ea63abab55300e666a930bf08ecb168010a3ea8494597b5cc63c5
+size 6976

--- a/packages/screenshots/testplane/chrome/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics.png
+++ b/packages/screenshots/testplane/chrome/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c18e2e628c4b8af758adb556b2504aad424712db423aee3c018664d9625fe78
+size 6972

--- a/packages/screenshots/testplane/firefox/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics-dark.png
+++ b/packages/screenshots/testplane/firefox/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a5c3544a0044a0df83e6b458c8af8a21ec8638fcd5486f1fa295bdd0cb823d7
+size 10227

--- a/packages/screenshots/testplane/firefox/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics.png
+++ b/packages/screenshots/testplane/firefox/components/collapsiblegroup/keep mounted, heading semantics/keep mounted, heading semantics.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d739504ad76163ab11532cc54ab4c4e60144f981fad3838f6989f0284f282d04
+size 9899

--- a/src/collapse/collapse-content.tsx
+++ b/src/collapse/collapse-content.tsx
@@ -83,6 +83,7 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
     // Armed once per collapse toggle from the --duration committed to the DOM — the value
     // the running transition actually uses — so it can neither undercut a transition started
     // from a stale height nor be restarted by content resizes or duration changes mid-collapse
+    // TODO merge with global/parse-css-duration when this lands in develop-8.0
     const cssDuration = parseFloat(container?.style.getPropertyValue('--duration') || '') || 0;
     const fallbackTimeout = window.setTimeout(finalizeCollapse, cssDuration + HIDE_FALLBACK_EXTRA_DELAY);
 
@@ -92,6 +93,9 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
     };
   }, [collapsed, initialContentHeight]);
 
+  // render-phase state adjustments (not effects): the React Compiler lint forbids
+  // setState-in-effect, and https://react.dev/learn/you-might-not-need-an-effect
+  // documents this pattern for resetting state when props change
   if (!collapsed && shouldHideContent) {
     setShouldHideContent(false);
   }

--- a/src/collapse/collapse-content.tsx
+++ b/src/collapse/collapse-content.tsx
@@ -13,8 +13,29 @@ const DURATION_FACTOR = 0.5;
 const DEFAULT_HEIGHT = 0;
 const VISIBLE = 1;
 const HIDDEN = 0;
+// margin for the hide fallback timer, so it fires only if transitionend never did
+const HIDE_FALLBACK_EXTRA_DELAY = 100;
+
+// React 18 renders unknown attributes from strings only, while React 19 treats `inert`
+// as a real boolean and removes the attribute when it gets ''
+// TODO drop the React 18 branch in develop-8.0 — Ring UI 8.0 supports React 19 only
+const REACT_MAJOR_WITH_INERT_SUPPORT = 19;
+const getInertAttributeValue = (reactMajor: number): true | '' =>
+  reactMajor >= REACT_MAJOR_WITH_INERT_SUPPORT ? true : '';
+// the cast is confined to the JSX assignment: React 18 actually receives the string form
+const INERT = getInertAttributeValue(Number(React.version.split('.')[0])) as unknown as boolean;
+
+const isFullyCollapsed = (collapsed: boolean, initialContentHeight: number) =>
+  collapsed && initialContentHeight <= DEFAULT_HEIGHT;
 
 interface Props {
+  /**
+   * Height of the always-visible preview of the collapsed content.
+   * The collapsed subtree is inert until expanded, matching `aria-expanded`.
+   * The preview is only a visual clip of that subtree, so it is inert too and
+   * assistive technology will not perceive it — if the preview carries essential
+   * information, expose an accessible summary outside the collapsed content.
+   */
   minHeight?: number;
   className?: string;
   'data-test'?: string | null | undefined;
@@ -29,7 +50,7 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
   minHeight = DEFAULT_HEIGHT,
   'data-test': dataTest,
 }) => {
-  const {collapsed, duration, id, disableAnimation} = useContext(CollapseContext);
+  const {collapsed, duration, id, disableAnimation, keepMounted} = useContext(CollapseContext);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [initialContentHeight] = useState<number>(minHeight);
@@ -41,22 +62,43 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
   const [shouldHideContent, setShouldHideContent] = useState<boolean>(collapsed && minHeight <= DEFAULT_HEIGHT);
 
   useEffect(() => {
-    function onTransitionEnd() {
+    const container = containerRef.current;
+
+    function finalizeCollapse() {
       if (initialContentHeight <= DEFAULT_HEIGHT) {
         setShouldHideContent(collapsed);
       }
     }
 
-    const container = containerRef.current;
+    function onTransitionEnd(event: TransitionEvent) {
+      // transitionend bubbles: only the container's own height transition finalizes the collapse
+      if (event.target === container && event.propertyName === 'height') {
+        finalizeCollapse();
+      }
+    }
+
     container?.addEventListener('transitionend', onTransitionEnd);
+    // fallback for suppressed or cancelled transitions (e.g. `transition: none` overrides),
+    // which emit no transitionend and would otherwise leave the content interactive forever.
+    // Armed once per collapse toggle from the --duration committed to the DOM — the value
+    // the running transition actually uses — so it can neither undercut a transition started
+    // from a stale height nor be restarted by content resizes or duration changes mid-collapse
+    const cssDuration = parseFloat(container?.style.getPropertyValue('--duration') || '') || 0;
+    const fallbackTimeout = window.setTimeout(finalizeCollapse, cssDuration + HIDE_FALLBACK_EXTRA_DELAY);
 
     return () => {
       container?.removeEventListener('transitionend', onTransitionEnd);
+      window.clearTimeout(fallbackTimeout);
     };
   }, [collapsed, initialContentHeight]);
 
   if (!collapsed && shouldHideContent) {
     setShouldHideContent(false);
+  }
+
+  // without a transition there is no transitionend to wait for, so hide immediately
+  if (disableAnimation && !shouldHideContent && isFullyCollapsed(collapsed, initialContentHeight)) {
+    setShouldHideContent(true);
   }
 
   useEffect(() => {
@@ -78,7 +120,13 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
 
   const fadeShouldBeVisible = Boolean(minHeight && collapsed);
 
-  const shouldRenderContent = disableAnimation ? !collapsed : !shouldHideContent;
+  const contentVisible = !shouldHideContent;
+  const contentHidden = Boolean(keepMounted) && !contentVisible;
+  // interaction is blocked as soon as the panel collapses (matching aria-expanded), while
+  // visibility waits for the animation to finish so the content stays painted meanwhile.
+  // This includes a minHeight preview: content clipped below it must not take focus,
+  // and inert cannot be applied any more granularly than to the whole subtree
+  const contentInert = collapsed;
 
   return (
     <div
@@ -88,8 +136,16 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
       className={classNames(styles.container, {[styles.transition]: !disableAnimation})}
       style={style}
     >
-      <div ref={contentRef} data-test={dataTests(COLLAPSE_CONTENT_TEST_ID, dataTest)}>
-        {shouldRenderContent ? children : null}
+      <div
+        ref={contentRef}
+        data-test={dataTests(COLLAPSE_CONTENT_TEST_ID, dataTest)}
+        // visibility: hidden removes the fully collapsed content from the tab order and accessibility
+        // tree, but descendants can override it with visibility: visible — inert cannot be escaped.
+        // Both are rendered in JSX so server-rendered collapsed markup is protected before hydration.
+        style={contentHidden ? {visibility: 'hidden'} : undefined}
+        inert={contentInert ? INERT : undefined}
+      >
+        {keepMounted || contentVisible ? children : null}
       </div>
       {fadeShouldBeVisible && <div className={styles.fade} />}
     </div>

--- a/src/collapse/collapse-context.ts
+++ b/src/collapse/collapse-context.ts
@@ -6,6 +6,7 @@ interface CollapseContextInterface {
   collapsed: boolean;
   duration: number;
   disableAnimation: boolean;
+  keepMounted?: boolean;
   setCollapsed: () => void;
   id: string;
 }
@@ -14,6 +15,7 @@ export const CollapseContext = createContext<CollapseContextInterface>({
   collapsed: true,
   duration: BASE_ANIMATION_DURATION,
   disableAnimation: false,
+  keepMounted: false,
   setCollapsed: () => {},
   id: '',
 });

--- a/src/collapse/collapse.test.tsx
+++ b/src/collapse/collapse.test.tsx
@@ -1,14 +1,23 @@
 import {type PropsWithChildren, useState} from 'react';
 import * as React from 'react';
-import {render, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {renderToStaticMarkup} from 'react-dom/server';
 
-import {COLLAPSE_CONTENT_CONTAINER_TEST_ID} from './consts';
+import {COLLAPSE_CONTENT_CONTAINER_TEST_ID, COLLAPSE_CONTENT_TEST_ID} from './consts';
 import {Collapse} from './collapse';
 import {CollapseContent} from './collapse-content';
 import {CollapseControl} from './collapse-control';
 
+import type * as globalDom from '../global/dom';
+
 import styles from './collapse.css';
+
+const getRectMock = vi.hoisted(() => vi.fn(() => ({top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0})));
+vi.mock('../global/dom', async importOriginal => ({
+  ...(await importOriginal<typeof globalDom>()),
+  getRect: getRectMock,
+}));
 
 const textMock = `This is very long text! This is very long text! This is very long text! This is very
             long text! This is very long text! This is very long text! This is very long text! This
@@ -24,6 +33,13 @@ const TextWrapper: React.FC<PropsWithChildren> = ({children}) => (
 );
 
 const onChangeMock = vi.fn();
+
+// jsdom has no TransitionEvent, so fireEvent.transitionEnd drops propertyName
+const fireTransitionEnd = (target: Element, propertyName: string) => {
+  const event = new Event('transitionend', {bubbles: true});
+  Object.assign(event, {propertyName});
+  fireEvent(target, event);
+};
 
 const Dummy = ({
   minHeight,
@@ -148,6 +164,315 @@ describe('<Collapse />', () => {
     const content = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
 
     expect(content.className).to.not.include(styles.transition);
+  });
+
+  it('should keep content mounted but hidden when keepMounted is set', async () => {
+    render(
+      <Collapse keepMounted disableAnimation>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent>{textMock}</CollapseContent>
+      </Collapse>,
+    );
+
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    expect(content).to.contain.text(textMock);
+    expect(content.style.visibility).to.equal('hidden');
+    expect(content.hasAttribute('inert')).to.equal(true);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+    expect(content.style.visibility).to.equal('');
+    expect(content.hasAttribute('inert')).to.equal(false);
+    expect(content).to.contain.text(textMock);
+  });
+
+  it('should hide kept-mounted content after the collapse transition ends', async () => {
+    render(
+      <Collapse keepMounted defaultCollapsed={false}>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent>{textMock}</CollapseContent>
+      </Collapse>,
+    );
+
+    const container = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    expect(content.style.visibility).to.equal('');
+    expect(content.hasAttribute('inert')).to.equal(false);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+    // interaction is blocked immediately on collapse,
+    // while the content stays painted during the animation
+    expect(content.hasAttribute('inert')).to.equal(true);
+    expect(content.style.visibility).to.equal('');
+
+    // a bubbling descendant transition must not finalize the collapse early
+    fireTransitionEnd(content, 'height');
+    expect(content.style.visibility).to.equal('');
+
+    // neither must a non-height transition of the container itself
+    fireTransitionEnd(container, 'opacity');
+    expect(content.style.visibility).to.equal('');
+
+    fireTransitionEnd(container, 'height');
+
+    expect(content).to.contain.text(textMock);
+    expect(content.style.visibility).to.equal('hidden');
+    expect(content.hasAttribute('inert')).to.equal(true);
+  });
+
+  it('should hide kept-mounted content even when no transitionend is ever fired', async () => {
+    render(
+      <Collapse keepMounted duration={1} defaultCollapsed={false}>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent>{textMock}</CollapseContent>
+      </Collapse>,
+    );
+
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+    // jsdom never emits transitionend, so only the fallback timer can hide the content
+    await waitFor(() => expect(content.style.visibility).to.equal('hidden'));
+    expect(content.hasAttribute('inert')).to.equal(true);
+  });
+
+  it('should not restart the hide fallback when kept-mounted content keeps resizing', () => {
+    vi.useFakeTimers();
+    let resize: (() => void) | undefined;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resize = () => callback([], this as unknown as ResizeObserver);
+        }
+
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+      },
+    );
+
+    try {
+      render(
+        <Collapse keepMounted defaultCollapsed={false}>
+          <CollapseControl>
+            <button type='button'>{'Toggle'}</button>
+          </CollapseControl>
+          <CollapseContent>{textMock}</CollapseContent>
+        </Collapse>,
+      );
+
+      const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+      fireEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+      // resize more often than the fallback deadline; jsdom never emits transitionend,
+      // so only a fallback timer that survives the churn can ever hide the content
+      const churnRounds = 10;
+      const churnStep = 100;
+      let height = 0;
+      const churn = () => {
+        act(() => {
+          resize?.();
+          vi.advanceTimersByTime(churnStep);
+        });
+      };
+      for (let i = 0; i < churnRounds; i++) {
+        height += churnStep;
+        getRectMock.mockReturnValue({top: 0, right: 0, bottom: 0, left: 0, width: 0, height});
+        churn();
+      }
+
+      expect(content.style.visibility).to.equal('hidden');
+      expect(content.hasAttribute('inert')).to.equal(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not hide kept-mounted content before the running transition can finish', () => {
+    vi.useFakeTimers();
+    let resize: (() => void) | undefined;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resize = () => callback([], this as unknown as ResizeObserver);
+        }
+
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+      },
+    );
+
+    try {
+      render(
+        <Collapse keepMounted defaultCollapsed={false}>
+          <CollapseControl>
+            <button type='button'>{'Toggle'}</button>
+          </CollapseControl>
+          <CollapseContent>{textMock}</CollapseContent>
+        </Collapse>,
+      );
+
+      const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+      // grow the content so the collapse transition gets a long duration (200 + 1000 * 0.5 = 700ms)
+      getRectMock.mockReturnValue({top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 1000});
+      act(() => resize?.());
+
+      // the content shrinks in the same update that collapses the panel:
+      // the fallback must follow the committed --duration, not the fresh DOM height
+      getRectMock.mockReturnValue({top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0});
+      fireEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+      act(() => vi.advanceTimersByTime(400));
+      expect(content.style.visibility).to.equal('');
+
+      act(() => vi.advanceTimersByTime(500));
+      expect(content.style.visibility).to.equal('hidden');
+      expect(content.hasAttribute('inert')).to.equal(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should keep focusable content below a collapsed minHeight preview out of the tab order', async () => {
+    render(
+      <Collapse>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent minHeight={MIN_HEIGHT}>
+          <button type='button'>{'Below the preview'}</button>
+        </CollapseContent>
+      </Collapse>,
+    );
+
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    expect(content.hasAttribute('inert')).to.equal(true);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+    expect(content.hasAttribute('inert')).to.equal(false);
+  });
+
+  it('should make a kept-mounted minHeight preview inert while collapsed', () => {
+    render(
+      <Collapse keepMounted disableAnimation>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent minHeight={MIN_HEIGHT}>
+          <button type='button'>{'Inside the preview'}</button>
+        </CollapseContent>
+      </Collapse>,
+    );
+
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    // the preview stays painted, but nothing in the collapsed subtree may take focus
+    expect(content.style.visibility).to.equal('');
+    expect(content.hasAttribute('inert')).to.equal(true);
+  });
+
+  it('should not re-arm the hide fallback when duration is lowered mid-collapse', () => {
+    vi.useFakeTimers();
+
+    const ui = (duration: number, collapsed: boolean) => (
+      <Collapse keepMounted duration={duration} collapsed={collapsed}>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent>{textMock}</CollapseContent>
+      </Collapse>
+    );
+
+    try {
+      const {rerender} = render(ui(1000, false));
+      const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+      rerender(ui(1000, true));
+
+      act(() => vi.advanceTimersByTime(300));
+
+      // lowering duration must not replace the running collapse's fallback with a shorter one
+      rerender(ui(0, true));
+
+      act(() => vi.advanceTimersByTime(200));
+      expect(content.style.visibility).to.equal('');
+
+      act(() => vi.advanceTimersByTime(700));
+      expect(content.style.visibility).to.equal('hidden');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should protect server-rendered collapsed markup with visibility and inert', () => {
+    const markup = renderToStaticMarkup(
+      <Collapse keepMounted>
+        <CollapseContent>
+          <button type='button' style={{visibility: 'visible'}}>
+            {'Escaping child'}
+          </button>
+        </CollapseContent>
+      </Collapse>,
+    );
+
+    expect(markup).to.include('inert');
+    expect(markup).to.include('visibility:hidden');
+  });
+
+  it('should keep the minHeight preview rendered when animation is disabled', () => {
+    renderComponent(MIN_HEIGHT, true);
+
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    expect(content).to.contain.text(textMock);
+    expect(content.style.visibility).to.equal('');
+  });
+
+  it('should keep kept-mounted content hidden when disableAnimation is turned off while collapsed', () => {
+    const ui = (collapsed: boolean, disableAnimation: boolean) => (
+      <Collapse keepMounted collapsed={collapsed} disableAnimation={disableAnimation}>
+        <CollapseControl>
+          <button type='button'>{'Toggle'}</button>
+        </CollapseControl>
+        <CollapseContent>{textMock}</CollapseContent>
+      </Collapse>
+    );
+
+    const {rerender} = render(ui(false, true));
+    const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+
+    expect(content.style.visibility).to.equal('');
+
+    rerender(ui(true, true));
+
+    expect(content.style.visibility).to.equal('hidden');
+    expect(content.hasAttribute('inert')).to.equal(true);
+
+    rerender(ui(true, false));
+
+    expect(content.style.visibility).to.equal('hidden');
+    expect(content.hasAttribute('inert')).to.equal(true);
   });
 
   it('should be able to expand by default', () => {

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -8,6 +8,15 @@ interface Props {
   onChange?: (collapsed: boolean) => void;
   duration?: number;
   disableAnimation?: boolean;
+  /**
+   * Keep children mounted while collapsed (hidden via CSS)
+   * instead of unmounting them, preserving their state.
+   * Note: hidden form controls still participate in form validation
+   * and submission — disable them while collapsed if needed.
+   * Content rendered through portals (e.g. Popup) escapes the hidden
+   * wrapper and is not hidden — close overlays on collapse.
+   */
+  keepMounted?: boolean;
   className?: string;
   defaultCollapsed?: boolean;
   collapsed?: boolean | null;
@@ -21,6 +30,7 @@ export const Collapse: React.FC<PropsWithChildren<Props>> = ({
   children,
   duration = BASE_ANIMATION_DURATION,
   disableAnimation = false,
+  keepMounted = false,
   className = '',
   onChange = () => {},
   defaultCollapsed = true,
@@ -44,6 +54,7 @@ export const Collapse: React.FC<PropsWithChildren<Props>> = ({
           setCollapsed,
           duration,
           disableAnimation,
+          keepMounted,
           id,
         }}
       >

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -9,8 +9,8 @@ interface Props {
   duration?: number;
   disableAnimation?: boolean;
   /**
-   * Keep children mounted while collapsed (hidden via CSS)
-   * instead of unmounting them, preserving their state.
+   * Keep children mounted while collapsed (hidden via `visibility: hidden`
+   * and the `inert` attribute) instead of unmounting them, preserving their state.
    * Note: hidden form controls still participate in form validation
    * and submission — disable them while collapsed if needed.
    * Content rendered through portals (e.g. Popup) escapes the hidden

--- a/src/collapsible-group/collapsible-group.css
+++ b/src/collapsible-group/collapsible-group.css
@@ -37,6 +37,12 @@
   height: 28px;
 }
 
+.heading {
+  margin: 0;
+
+  font: inherit;
+}
+
 .headerButton {
   display: block;
 

--- a/src/collapsible-group/collapsible-group.stories.tsx
+++ b/src/collapsible-group/collapsible-group.stories.tsx
@@ -94,3 +94,21 @@ CollapsedByDefault.parameters = {
     actions: [{type: 'capture', name: '', selector: captureSelector}],
   },
 };
+
+export const KeepMountedWithHeading = () => (
+  <div className={styles.row}>
+    <CollapsibleGroup
+      className={styles.card}
+      title={'Deployments'}
+      subtitle={'Type below, collapse and expand — the draft survives'}
+      headingLevel={3}
+      keepMounted
+    >
+      <form className={styles.form} onSubmit={event => event.preventDefault()}>
+        <Input label='Step name' placeholder='Kept mounted while collapsed' />
+      </form>
+    </CollapsibleGroup>
+  </div>
+);
+
+KeepMountedWithHeading.storyName = 'Keep mounted, heading semantics';

--- a/src/collapsible-group/collapsible-group.test.tsx
+++ b/src/collapsible-group/collapsible-group.test.tsx
@@ -116,6 +116,69 @@ describe('<CollapsibleGroup />', () => {
     expect(root.className).not.toContain(styles.focused);
   });
 
+  it('should preserve child state across a collapse cycle when keepMounted is set', async () => {
+    // disableAnimation makes the collapse settle synchronously, so the cycle
+    // crosses the state where non-kept-mounted children would be unmounted
+    render(
+      <CollapsibleGroup title={'Title'} keepMounted defaultExpanded disableAnimation>
+        <input aria-label='Draft' />
+      </CollapsibleGroup>,
+    );
+
+    const header = screen.getByRole('button', {name: 'Title'});
+    const input = screen.getByLabelText<HTMLInputElement>('Draft');
+
+    await userEvent.type(input, 'preserved');
+
+    await userEvent.click(header);
+
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByLabelText('Draft')).toBe(input);
+
+    await userEvent.click(header);
+
+    const inputAfterCycle = screen.getByLabelText<HTMLInputElement>('Draft');
+    expect(inputAfterCycle).toBe(input);
+    expect(inputAfterCycle.value).toBe('preserved');
+  });
+
+  it('should wrap the header in a heading when headingLevel is set', () => {
+    renderExpand({headingLevel: 3});
+
+    const heading = screen.getByRole('heading', {level: 3});
+    const header = screen.getByRole('button', {name: 'Title'});
+
+    expect(heading.contains(header)).toBe(true);
+  });
+
+  it('should forward every class to the deprecated expand stylesheet', async () => {
+    // CSS modules are proxied in tests, so compare class tokens in the source files
+    const {readFile} = await import('node:fs/promises');
+    const read = (file: string) => readFile(`${process.cwd()}/src/${file}`, 'utf8');
+    // strip comments and quoted strings (import/composes paths),
+    // then collect .className tokens anywhere in a selector
+    const classTokens = (css: string) =>
+      new Set(
+        [
+          ...css
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/'[^']*'/g, '')
+            .matchAll(/\.([a-zA-Z_][\w-]*)/g),
+        ].map(match => match[1]),
+      );
+
+    const deprecatedCss = await read('expand/collapsible-group.css');
+    const canonical = classTokens(await read('collapsible-group/collapsible-group.css'));
+    const deprecated = classTokens(deprecatedCss);
+
+    expect([...deprecated].sort()).toEqual([...canonical].sort());
+
+    // duplicate selector names are not enough — every alias must actually forward the canonical rule
+    for (const token of canonical) {
+      expect(deprecatedCss).toContain(`composes: ${token} from`);
+    }
+  });
+
   it('should support disabling animation', async () => {
     renderExpand({disableAnimation: true});
 

--- a/src/collapsible-group/collapsible-group.tsx
+++ b/src/collapsible-group/collapsible-group.tsx
@@ -21,6 +21,20 @@ export interface CollapsibleGroupProps {
   onChange?: (expanded: boolean) => void;
   disableAnimation?: boolean;
   interactive?: boolean;
+  /**
+   * Keep children mounted while collapsed (hidden via CSS)
+   * instead of unmounting them, preserving their state.
+   * Note: hidden form controls still participate in form validation
+   * and submission — disable them while collapsed if needed.
+   * Content rendered through portals (e.g. Popup) escapes the hidden
+   * wrapper and is not hidden — close overlays on collapse.
+   */
+  keepMounted?: boolean;
+  /**
+   * Wraps the header in an <h2>–<h6> to keep the document outline.
+   */
+  // eslint-disable-next-line no-magic-numbers
+  headingLevel?: 2 | 3 | 4 | 5 | 6;
   'data-test'?: string | null | undefined;
 }
 
@@ -94,6 +108,8 @@ const CollapsibleGroup = forwardRef<HTMLDivElement, CollapsibleGroupProps>(
       onChange = () => {},
       disableAnimation = false,
       interactive = true,
+      keepMounted = false,
+      headingLevel,
       'data-test': dataTest,
     },
     ref,
@@ -125,6 +141,20 @@ const CollapsibleGroup = forwardRef<HTMLDivElement, CollapsibleGroupProps>(
       [styles.focused]: focused,
     });
 
+    const header = interactive ? (
+      <CollapsibleGroupHeader
+        avatar={avatar}
+        titleContent={title}
+        subtitle={subtitle}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setFocused(true)}
+        onBlur={onBlur}
+      />
+    ) : (
+      <CollapsibleGroupHeaderStatic avatar={avatar} titleContent={title} subtitle={subtitle} />
+    );
+
     return (
       <div ref={ref} className={classes} data-test={dataTest}>
         <Collapse
@@ -132,21 +162,10 @@ const CollapsibleGroup = forwardRef<HTMLDivElement, CollapsibleGroupProps>(
           collapsed={expanded == null ? null : !expanded}
           onChange={handleChange}
           disableAnimation={disableAnimation}
+          keepMounted={keepMounted}
           className={styles.collapseRoot}
         >
-          {interactive ? (
-            <CollapsibleGroupHeader
-              avatar={avatar}
-              titleContent={title}
-              subtitle={subtitle}
-              onMouseEnter={() => setHovered(true)}
-              onMouseLeave={() => setHovered(false)}
-              onFocus={() => setFocused(true)}
-              onBlur={onBlur}
-            />
-          ) : (
-            <CollapsibleGroupHeaderStatic avatar={avatar} titleContent={title} subtitle={subtitle} />
-          )}
+          {headingLevel != null ? React.createElement(`h${headingLevel}`, {className: styles.heading}, header) : header}
           <CollapseContent>
             <div className={styles.body}>{children}</div>
           </CollapseContent>

--- a/src/collapsible-group/collapsible-group.tsx
+++ b/src/collapsible-group/collapsible-group.tsx
@@ -22,8 +22,8 @@ export interface CollapsibleGroupProps {
   disableAnimation?: boolean;
   interactive?: boolean;
   /**
-   * Keep children mounted while collapsed (hidden via CSS)
-   * instead of unmounting them, preserving their state.
+   * Keep children mounted while collapsed (hidden via `visibility: hidden`
+   * and the `inert` attribute) instead of unmounting them, preserving their state.
    * Note: hidden form controls still participate in form validation
    * and submission — disable them while collapsed if needed.
    * Content rendered through portals (e.g. Popup) escapes the hidden

--- a/src/expand/collapsible-group.css
+++ b/src/expand/collapsible-group.css
@@ -27,6 +27,10 @@
   composes: header from '../collapsible-group/collapsible-group.css';
 }
 
+.heading {
+  composes: heading from '../collapsible-group/collapsible-group.css';
+}
+
 .headerButton {
   composes: headerButton from '../collapsible-group/collapsible-group.css';
 }


### PR DESCRIPTION
## What

- **`keepMounted`** (opt-in, default off) on `Collapse` and `CollapsibleGroup`: keeps collapsed content mounted — hidden via `visibility: hidden` + `inert` — instead of unmounting it, so local state, subscriptions, and iframes survive collapse cycles. Documented limitations: portaled content (e.g. `Popup`) is not hidden, and hidden form controls still participate in constraint validation.
- **`headingLevel?: 2–6`** on `CollapsibleGroup`: wraps the disclosure header in an `<h2>`–`<h6>` (standard `<hN><button aria-expanded>` accordion pattern) to preserve the document outline.

## Behavior changes / fixes along the way

- `CollapseContent` is now `inert` whenever the panel is collapsed, matching `aria-expanded`: content animating shut can't be tabbed into, and a `minHeight` preview is a visual-only teaser (see the `minHeight` JSDoc for the AT trade-off).
- Collapse finalization only reacts to the container's **own `height` transitionend** (descendant transitions used to end it early), with a once-per-collapse fallback timer derived from the committed `--duration` for suppressed/cancelled transitions (`transition: none`, reduced motion).
- `disableAnimation` no longer unmounts a positive-`minHeight` preview, and stays in sync when toggled while collapsed.
- `keepMounted` is optional in `CollapseContext`, so externally constructed `Provider` values keep compiling.
- `inert` is serialized cross-version (React 19 boolean vs React 18 empty-string form) and rendered in JSX so SSR markup is protected before hydration. TODO markers note that the React 18 branch should be dropped in develop-8.0.
- The deprecated `expand/collapsible-group.css` alias forwards the new `heading` class, guarded by a token-parity + composes test.

## CI

- New **React 18 runtime compatibility** TeamCity build (`.teamcity/src/tests/React18Compat.kt`), wired as a snapshot dependency of `All checks`. ⚠️ The DSL is untested locally — please sanity-check it compiles on the TeamCity side.

## Tests

25 unit tests across `src/collapse` / `src/collapsible-group`, covering: state preservation across a settled collapse cycle, immediate `inert` on collapse, transitionend target/property filtering, fallback-timer behavior under resize churn / mid-collapse `duration` changes / stale-height starts, SSR markup, `minHeight` previews, and heading semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)