### PR TITLE
RG-2809 Add Trusted Types policy hook

### DIFF
--- a/src/contenteditable/contenteditable.test.tsx
+++ b/src/contenteditable/contenteditable.test.tsx
@@ -1,5 +1,6 @@
 import {render, screen} from '@testing-library/react';
 
+import {configure} from '../global/configuration';
 import ContentEditable from './contenteditable';
 
 describe('ContentEditable', () => {
@@ -24,6 +25,26 @@ describe('ContentEditable', () => {
       </ContentEditable>,
     );
     expect(screen.getByText('bold')).to.have.tagName('b');
+  });
+
+  it('should apply configured Trusted Types policy to html', () => {
+    const trustedTypePolicy = {
+      createHTML: vi.fn((html: string) => html),
+    };
+
+    configure({trustedTypePolicy});
+
+    try {
+      render(
+        <ContentEditable>
+          <b>{'bold'}</b>
+        </ContentEditable>,
+      );
+
+      expect(trustedTypePolicy.createHTML).toHaveBeenCalledWith('<b>bold</b>');
+    } finally {
+      configure({trustedTypePolicy: null});
+    }
   });
 
   it('should render only on html / disabled change', () => {

--- a/src/contenteditable/contenteditable.tsx
+++ b/src/contenteditable/contenteditable.tsx
@@ -1,6 +1,8 @@
 import {Component, type HTMLAttributes, type Ref, type ReactElement} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
 
+import {getTrustedHTML} from '../global/configuration';
+
 /**
  * @name ContentEditable
  */
@@ -44,7 +46,7 @@ class ContentEditableBase extends Component<ContentEditableBaseProps> {
         role='textbox'
         tabIndex={disabled ? undefined : tabIndex}
         contentEditable={!this.props.disabled}
-        dangerouslySetInnerHTML={{__html}}
+        dangerouslySetInnerHTML={{__html: getTrustedHTML(__html)}}
       />
     );
   }

--- a/src/global/configuration.ts
+++ b/src/global/configuration.ts
@@ -4,14 +4,20 @@ export enum ControlsHeight {
   L = 'L',
 }
 
+export interface RingUITrustedTypePolicy {
+  createHTML(html: string): TrustedHTML;
+}
+
 export interface RingUIConfiguration {
   controlsHeight?: ControlsHeight;
   popupsCssPositioning?: boolean;
+  trustedTypePolicy?: RingUITrustedTypePolicy | null;
 }
 
 const globalConfiguration: Required<RingUIConfiguration> = {
   controlsHeight: ControlsHeight.M,
   popupsCssPositioning: true,
+  trustedTypePolicy: null,
 };
 
 export function configure(config: RingUIConfiguration): void {
@@ -21,8 +27,15 @@ export function configure(config: RingUIConfiguration): void {
   if (config.popupsCssPositioning !== undefined) {
     globalConfiguration.popupsCssPositioning = config.popupsCssPositioning;
   }
+  if (config.trustedTypePolicy !== undefined) {
+    globalConfiguration.trustedTypePolicy = config.trustedTypePolicy;
+  }
 }
 
 export function getConfiguration(): Required<RingUIConfiguration> {
   return {...globalConfiguration};
+}
+
+export function getTrustedHTML(html: string): string | TrustedHTML {
+  return globalConfiguration.trustedTypePolicy?.createHTML(html) ?? html;
 }

--- a/src/icon/icon-svg.tsx
+++ b/src/icon/icon-svg.tsx
@@ -2,6 +2,7 @@
 import {memo, type SVGAttributes} from 'react';
 import classNames from 'classnames';
 
+import {getTrustedHTML} from '../global/configuration';
 import memoize from '../global/memoize';
 
 import styles from './icon.css';
@@ -33,7 +34,7 @@ function extractSVGProps(svgNode: Element) {
 
 const getSVGFromSource = memoize((src: string) => {
   const svgContainer = document.createElement('div');
-  svgContainer.innerHTML = src;
+  svgContainer.innerHTML = getTrustedHTML(src) as string;
   const svg = svgContainer.firstElementChild as Element;
   if (svg.remove) {
     svg.remove();
@@ -73,7 +74,7 @@ function IconSVG({src, className, ...rest}: IconSVGProps) {
       {...rest}
       className={glyphClasses}
       dangerouslySetInnerHTML={{
-        __html: html,
+        __html: getTrustedHTML(html),
       }}
     />
   );

--- a/src/icon/icon.test.tsx
+++ b/src/icon/icon.test.tsx
@@ -2,6 +2,7 @@ import {render, screen} from '@testing-library/react';
 import defaultIcon from '@jetbrains/icons/umbrella';
 import expandIcon from '@jetbrains/icons/expand';
 
+import {configure} from '../global/configuration';
 import Icon, {type IconAttrs} from './icon';
 
 import styles from './icon.css';
@@ -35,6 +36,24 @@ describe('Icon', () => {
     const icon = renderIcon({glyph: expandIcon, className: CUSTOM_CSS_CLASS})!;
 
     expect(icon).to.have.class(CUSTOM_CSS_CLASS);
+  });
+
+  it('should apply configured Trusted Types policy to SVG strings', () => {
+    const glyph = '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13"><path d="M0 0"/></svg>';
+    const trustedTypePolicy = {
+      createHTML: vi.fn((html: string) => html),
+    };
+
+    configure({trustedTypePolicy});
+
+    try {
+      renderIcon({glyph});
+
+      expect(trustedTypePolicy.createHTML).toHaveBeenCalledWith(glyph);
+      expect(trustedTypePolicy.createHTML).toHaveBeenCalledWith('<path d="M0 0"></path>');
+    } finally {
+      configure({trustedTypePolicy: null});
+    }
   });
 
   describe('fault tolerance', () => {


### PR DESCRIPTION
## Motivation
Ring UI injects SVG and rich content through `innerHTML` in a few shared components. Host applications that enable [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) can reject those string assignments, so Ring UI needs a single way to receive and use the host's Trusted Types policy instead of forcing every consumer to work around each component separately.

Issue: [RG-2809](https://youtrack.jetbrains.com/issue/RG-2809)

## Summary
- Add a global Trusted Types policy hook to Ring UI configuration
- Apply the configured policy to Icon SVG and ContentEditable innerHTML sinks
- Cover both consumers with regression tests
