### PR TITLE
Fix Storybook height on mobile Safari

### DIFF
--- a/.storybook/custom-header/header-styles.css
+++ b/.storybook/custom-header/header-styles.css
@@ -7,7 +7,7 @@
  */
 /* stylelint-disable-next-line selector-max-specificity */
 :global(#root) > div {
-  height: calc(100vh - 64px);
+  height: calc(100dvh - 64px);
 }
 
 .header {


### PR DESCRIPTION
## Summary

Use the dynamic viewport height for the custom Storybook layout so its mobile navigation stays above iPhone Safari browser chrome.

## Verification

- `npm run prepare`
- Stylelint
- `git diff --check`

No screenshot baselines changed.