### PR TITLE
fix(tooltip): TW-98285 anchor block triggers correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Removed the deprecated `expand/collapsible-group` component and CSS import aliases; import them from `collapsible-group/collapsible-group` instead.
 - Removed the deprecated `--ring-border-disabled-active-color`, `--ring-action-link-color`, and `--ring-button-primary-background-color` CSS variables; use `--ring-border-hover-color`, `--ring-link-color`, and `--ring-main-color`, respectively.
 - Removed the deprecated `--ring-pinned-shadow-color`, `--ring-hint-color`, and `--ring-button-loader-background` CSS variables. Use `--ring-popup-shadow-color` or a product-specific token for shadows and `--ring-secondary-color` for muted text, choosing a more specific semantic token where appropriate. Button loader colors are now derived per variant; override the component-scoped `--ring-button-loader-components` RGB components only for custom styling.
+- `Tooltip` props now use `AllHTMLAttributes<HTMLElement>` instead of `AllHTMLAttributes<HTMLSpanElement>`. Use the new `TagName` prop to select a `span` or `div` wrapper; it defaults to `span`.
 
 ## [7.0.121]
 - Added `keepMounted` prop to `Collapse` and `CollapsibleGroup` that keeps collapsed content mounted (hidden via `visibility: hidden` and `inert`) instead of unmounting it, preserving local state, subscriptions and iframes. Limitations: content rendered through portals (e.g. `Popup`) is not hidden, and hidden form controls still participate in form validation — disable them while collapsed if needed.

--- a/src/tooltip/tooltip.test.tsx
+++ b/src/tooltip/tooltip.test.tsx
@@ -86,6 +86,12 @@ describe('Tooltip', () => {
       expect(within(wrapper).getByText('test span').tagName.toLowerCase()).to.equal('span');
     });
 
+    it('should use the provided tag name', () => {
+      renderTooltip({TagName: 'div'});
+
+      expect(screen.getByRole('tooltip').tagName.toLowerCase()).to.equal('div');
+    });
+
     it('should pass props to children', () => {
       renderTooltip();
       // Using a more specific selector

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -19,7 +19,8 @@ interface Context {
 
 const TooltipContext = createContext<Context | undefined>(undefined);
 
-export interface TooltipProps extends Omit<AllHTMLAttributes<HTMLSpanElement>, 'title'> {
+export interface TooltipProps extends Omit<AllHTMLAttributes<HTMLElement>, 'title'> {
+  TagName?: 'span' | 'div' | null | undefined;
   delay?: number | null | undefined;
   selfOverflowOnly?: boolean | null | undefined;
   popupProps?: Partial<PopupAttrs> | null | undefined;
@@ -175,6 +176,7 @@ export default class Tooltip extends Component<TooltipProps> {
   render() {
     const {
       children,
+      TagName,
       'data-test': dataTest,
       title,
       delay,
@@ -190,6 +192,7 @@ export default class Tooltip extends Component<TooltipProps> {
       typeof title === 'string' && Tooltip.isShow({title, hide}) ? {'aria-label': title, role: 'tooltip'} : {};
 
     const {onNestedTooltipShow, onNestedTooltipHide} = this;
+    const WrapperElement = TagName || 'span';
 
     const popup = (
       <Popup
@@ -216,7 +219,7 @@ export default class Tooltip extends Component<TooltipProps> {
 
     return (
       <TooltipContext value={{onNestedTooltipShow, onNestedTooltipHide}}>
-        <span
+        <WrapperElement
           {...ariaProps}
           {...restProps}
           ref={this.containerRef}
@@ -231,7 +234,7 @@ export default class Tooltip extends Component<TooltipProps> {
               {popup}
             </ThemeProvider>
           )}
-        </span>
+        </WrapperElement>
       </TooltipContext>
     );
   }


### PR DESCRIPTION
[TW-98285](https://youtrack.jetbrains.com/issue/TW-98285) "Expand" tooltip blocks the expand sidebar button

This only happens with js positioning when a block element (e.g. div) is wrapped in a tooltip. The fix allows users to pass a different TagName for correct display