### PR TITLE
Add popupProps to Select

### DIFF
--- a/src/select/select-popup.tsx
+++ b/src/select/select-popup.tsx
@@ -616,7 +616,7 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
               onMouseDown={this.mouseDownHandler}
               target={this.props.ringPopupTarget}
               autoCorrectTopOverflow={false}
-              style={{...style, ...popupProps?.style}}
+              style={{...popupProps?.style, ...style}}
               largeBorderRadius
             >
               <div dir={dir}>

--- a/src/select/select-popup.tsx
+++ b/src/select/select-popup.tsx
@@ -585,7 +585,7 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
       filter,
       popupProps,
     } = this.props;
-    const classes = classNames(styles.popup, className);
+    const classes = classNames(styles.popup, className, popupProps?.className);
 
     return (
       <PopupTargetContext.Consumer>
@@ -598,6 +598,7 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
           const hasContent = filterWithTags || selectAll || list || bottomLine || toolbar || topbar;
           return (
             <Popup
+              {...popupProps}
               trapFocus={false}
               ref={this.popupRef}
               hidden={hidden || !hasContent}
@@ -615,9 +616,8 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
               onMouseDown={this.mouseDownHandler}
               target={this.props.ringPopupTarget}
               autoCorrectTopOverflow={false}
-              style={style}
+              style={{...style, ...popupProps?.style}}
               largeBorderRadius
-              {...popupProps}
             >
               <div dir={dir}>
                 {!hidden && filter && <Shortcuts map={this.shortcutsMap} scope={this.shortcutsScope} />}

--- a/src/select/select-popup.tsx
+++ b/src/select/select-popup.tsx
@@ -16,7 +16,7 @@ import searchIcon from '@jetbrains/icons/search';
 import memoizeOne from 'memoize-one';
 
 import Icon, {type IconType} from '../icon/icon';
-import Popup, {getPopupContainer} from '../popup/popup';
+import Popup, {getPopupContainer, type PopupAttrs} from '../popup/popup';
 import {type Directions, maxHeightForDirection} from '../popup/position';
 import {normalizePopupTarget, PopupTargetContext} from '../popup/popup.target';
 import List, {type SelectHandlerParams} from '../list/list';
@@ -101,6 +101,7 @@ export interface SelectPopupProps<T = unknown> {
   ringPopupTarget: string | null;
   onSelectAll: (isSelectAll: boolean) => void;
   onEmptyPopupEnter: (e: KeyboardEvent) => void;
+  popupProps?: Partial<PopupAttrs> | undefined;
   className?: string | null | undefined;
   compact?: boolean | null | undefined;
   dir?: 'ltr' | 'rtl' | undefined;
@@ -582,6 +583,7 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
       style,
       dir,
       filter,
+      popupProps,
     } = this.props;
     const classes = classNames(styles.popup, className);
 
@@ -615,6 +617,7 @@ export default class SelectPopup<T = unknown> extends PureComponent<SelectPopupP
               autoCorrectTopOverflow={false}
               style={style}
               largeBorderRadius
+              {...popupProps}
             >
               <div dir={dir}>
                 {!hidden && filter && <Shortcuts map={this.shortcutsMap} scope={this.shortcutsScope} />}

--- a/src/select/select.test.tsx
+++ b/src/select/select.test.tsx
@@ -75,6 +75,14 @@ describe('Select', () => {
     expect(screen.getByTestId('ring-select')).to.have.class('foo-bar');
   });
 
+  it('Should pass popupProps to the popup', async () => {
+    const onMouseEnter = vi.fn();
+    renderSelect({popupProps: {'data-test': 'job-dependency-options-popup', onMouseEnter}});
+    await userEvent.click(screen.getByRole('combobox', {name: 'first1'}));
+    fireEvent.mouseEnter(screen.getByTestId(/job-dependency-options-popup/));
+    expect(onMouseEnter).toHaveBeenCalledOnce();
+  });
+
   it('Should highlight selected item', async () => {
     renderSelect({selected: testData[2]});
     const button = screen.getByRole('combobox', {name: 'test3'});

--- a/src/select/select.test.tsx
+++ b/src/select/select.test.tsx
@@ -77,9 +77,9 @@ describe('Select', () => {
 
   it('Should pass popupProps to the popup', async () => {
     const onMouseEnter = vi.fn();
+    const user = userEvent.setup();
     renderSelect({popupProps: {'data-test': 'job-dependency-options-popup', onMouseEnter}});
-    await userEvent.click(screen.getByRole('combobox', {name: 'first1'}));
-    fireEvent.mouseEnter(screen.getByTestId(/job-dependency-options-popup/));
+    await user.click(screen.getByRole('combobox', {name: 'first1'}));
     expect(onMouseEnter).toHaveBeenCalledOnce();
   });
 

--- a/src/select/select.test.tsx
+++ b/src/select/select.test.tsx
@@ -78,8 +78,24 @@ describe('Select', () => {
   it('Should pass popupProps to the popup', async () => {
     const onMouseEnter = vi.fn();
     const user = userEvent.setup();
-    renderSelect({popupProps: {'data-test': 'job-dependency-options-popup', onMouseEnter}});
+    renderSelect({
+      popupClassName: 'select-popup',
+      popupStyle: {color: 'red'},
+      popupProps: {
+        'data-test': 'job-dependency-options-popup',
+        className: 'custom-popup',
+        hidden: true,
+        onMouseEnter,
+        style: {backgroundColor: 'blue'},
+      },
+    });
     await user.click(screen.getByRole('combobox', {name: 'first1'}));
+    const popup = screen.getByTestId(/job-dependency-options-popup/);
+    expect(popup.classList.contains('select-popup')).to.be.true;
+    expect(popup.classList.contains('custom-popup')).to.be.true;
+    expect(popup.style.color).to.equal('red');
+    expect(popup.style.backgroundColor).to.equal('blue');
+    fireEvent.mouseEnter(popup);
     expect(onMouseEnter).toHaveBeenCalledOnce();
   });
 

--- a/src/select/select.test.tsx
+++ b/src/select/select.test.tsx
@@ -86,7 +86,7 @@ describe('Select', () => {
         className: 'custom-popup',
         hidden: true,
         onMouseEnter,
-        style: {backgroundColor: 'blue'},
+        style: {color: 'blue', backgroundColor: 'blue'},
       },
     });
     await user.click(screen.getByRole('combobox', {name: 'first1'}));

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -18,7 +18,7 @@ import {dequal} from 'dequal';
 
 import {Anchor} from '../dropdown/dropdown';
 import Avatar, {Size as AvatarSize} from '../avatar/avatar';
-import Popup from '../popup/popup';
+import Popup, {type PopupAttrs} from '../popup/popup';
 import List, {ActiveItemContext, type SelectHandlerParams} from '../list/list';
 import Input, {Size} from '../input/input';
 import ControlLabel, {type LabelType} from '../control-label/control-label';
@@ -194,6 +194,7 @@ export interface BaseSelectProps<T = unknown> {
   getInitial?: (() => string) | null | undefined;
   minWidth?: number | undefined;
   popupClassName?: string | null | undefined;
+  popupProps?: Partial<PopupAttrs> | undefined;
   popupStyle?: CSSProperties | undefined;
   top?: number | undefined;
   left?: number | undefined;
@@ -740,6 +741,7 @@ export default class Select<T = unknown> extends Component<SelectProps<T>, Selec
               maxHeight={this.props.maxHeight}
               minWidth={this.props.minWidth}
               directions={this.props.directions}
+              popupProps={this.props.popupProps}
               className={this.props.popupClassName}
               style={this.props.popupStyle}
               top={this.props.top}


### PR DESCRIPTION
Allow Select consumers to pass typed Popup props through SelectPopup to the underlying Popup. This supports custom data-test attributes and other Popup behavior overrides.

Tests:
- npx vitest run src/select/select.test.tsx
- npm run type-check
- npx eslint src/select/select.tsx src/select/select-popup.tsx src/select/select.test.tsx