### PR TITLE
RG-2812 Add Selection Toolbar

### DIFF
--- a/packages/screenshots/testplane/chrome/components/selection toolbar/compact/compact-dark.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/compact/compact-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e604be6631472b191b130805f1d811e3238bd7c4933b58324b14a9ff4e1d241
+size 8848

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/compact/compact.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/compact/compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e16c23a6d839b3e18fd58ccdd0f1db9e6d17d456f0a758605e5013f82534170
+size 9354

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/current page selected/current page selected-dark.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/current page selected/current page selected-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:987e7ada5f8dca1e2ffcd861e172662867f5d5f9fce4f658dc3d960e76a68f2b
+size 9910

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/current page selected/current page selected.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/current page selected/current page selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:393f0661518c33f1af367e623820553cd50adc0c6daf03d88d6091999b405773
+size 10466

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/partial selection/partial selection-dark.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/partial selection/partial selection-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e1aa661bec8f8a9e93ec44ca8ee9053c3063084f50ec0c55c80739b2d75e69f
+size 8985

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/partial selection/partial selection.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/partial selection/partial selection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31dfa650c99727425b1ec5609ac181c873cb1ebb560dd6134e20eed4b08020b5
+size 9432

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/rtl/rtl-dark.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/rtl/rtl-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dca67598f2bae4a905660315bc54f955d094749e0182f387decc5a8bdeb29911
+size 8878

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/rtl/rtl.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/rtl/rtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c258650dd43870a92fc2b9165c006229928de92cebe87d7d5571ad7e3861a802
+size 9331

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/with table/with table-dark.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/with table/with table-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ee214bd8064123e795a26e9a903beb198c6086ab109625d5ebe2fb660738fe
+size 17187

--- a/packages/screenshots/testplane/chrome/components/selection toolbar/with table/with table.png
+++ b/packages/screenshots/testplane/chrome/components/selection toolbar/with table/with table.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf81170040878918e631025077522580bcd3200a47bc55b6e1bea8bd25194607
+size 17881

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/compact/compact-dark.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/compact/compact-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ff96957329917e48524d78a70e626ce4a53245abe6e17690c42fa2875ffdaf
+size 12344

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/compact/compact.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/compact/compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4aadf9b36a26655bb0216199dc1fc1eae1c6192a58489d714b80d7cdb9f85e1
+size 12911

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/current page selected/current page selected-dark.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/current page selected/current page selected-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df82693afc0a28b2120d31e0531183ed4b4582d8d95ddc29dc181c8850d8d4dc
+size 12580

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/current page selected/current page selected.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/current page selected/current page selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:273ddb4a748f5e364591a7fa52f4d97f905d3117ee1b28702ba7a34c7e649b87
+size 13204

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/partial selection/partial selection-dark.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/partial selection/partial selection-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84b639475aa1cbda3eba93cb9f06e7a046c5a77677ad7007091e4a38a9cbdcc7
+size 10194

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/partial selection/partial selection.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/partial selection/partial selection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf2a7eb139f62f2b1b650930c2477dda0db76649684dc2c5a0730113f009776b
+size 10796

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/rtl/rtl-dark.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/rtl/rtl-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06a973c786a56e2c511b737d676a12f7b4ab9b13d231d5f8fc8e12dee7b6d688
+size 9761

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/rtl/rtl.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/rtl/rtl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c61cc465f88686568b567c3c29b6fcea8429d951bb54a6357f463672b449153
+size 10394

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/with table/with table-dark.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/with table/with table-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d55eda2b845d22dc77c4a0ce21c8a930dc03c81280cfeff4965ca961ece64018
+size 29041

--- a/packages/screenshots/testplane/firefox/components/selection toolbar/with table/with table.png
+++ b/packages/screenshots/testplane/firefox/components/selection toolbar/with table/with table.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68a6403f2371d63242564bf52ea0d81c03599082582642b85172aef0204b74c4
+size 29543

--- a/src/selection-toolbar/selection-toolbar.css
+++ b/src/selection-toolbar/selection-toolbar.css
@@ -1,0 +1,86 @@
+@import '../global/variables.css';
+
+.toolbar {
+  display: inline-flex;
+  align-items: center;
+
+  box-sizing: border-box;
+  max-width: 100%;
+  height: calc(var(--ring-unit) * 5);
+  padding: 10px calc(var(--ring-unit) * 2);
+
+  pointer-events: auto;
+
+  color: var(--ring-white-text-color);
+  border-radius: var(--ring-border-radius-large);
+  background-color: var(--ring-sidebar-background-color);
+  box-shadow:
+    0 2px 8px rgb(0 28 54 / 10%),
+    0 1px 2px rgb(0 28 54 / 4%);
+
+  line-height: var(--ring-line-height);
+  gap: calc(var(--ring-unit) * 2);
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--ring-unit) * 3);
+}
+
+.selectAll {
+  flex: none;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--ring-unit) * 2);
+
+  min-width: 0;
+}
+
+.closeAction {
+  flex: none;
+}
+
+.separator {
+  flex: none;
+
+  width: 1px;
+  height: calc(var(--ring-unit) * 2);
+  margin-inline: var(--ring-unit);
+
+  background-color: var(--ring-line-color);
+}
+
+.compact {
+  min-width: 0;
+  max-width: 100%;
+  padding-inline: 12px;
+}
+
+.compact .content {
+  min-width: 0;
+  gap: var(--ring-unit);
+}
+
+.compact .label {
+  overflow: hidden;
+
+  flex: 1 1 auto;
+
+  min-width: 0;
+
+  white-space: nowrap;
+
+  text-overflow: ellipsis;
+}
+
+.compact .actions {
+  flex-shrink: 1;
+}
+
+.compact .separator {
+  margin-inline: 2px;
+}

--- a/src/selection-toolbar/selection-toolbar.stories.css
+++ b/src/selection-toolbar/selection-toolbar.stories.css
@@ -1,0 +1,23 @@
+@import '../global/variables.css';
+
+.canvas {
+  position: relative;
+
+  box-sizing: border-box;
+  min-height: calc(100vh - var(--ring-unit) * 2);
+  padding: calc(var(--ring-unit) * 3);
+
+  background-color: var(--ring-content-background-color);
+}
+
+.toolbarPlacement {
+  position: absolute;
+  inset-inline: 0;
+
+  bottom: calc(var(--ring-unit) * 2);
+
+  display: flex;
+  justify-content: center;
+
+  pointer-events: none;
+}

--- a/src/selection-toolbar/selection-toolbar.stories.tsx
+++ b/src/selection-toolbar/selection-toolbar.stories.tsx
@@ -1,0 +1,183 @@
+import closeIcon from '@jetbrains/icons/close';
+import linkIcon from '@jetbrains/icons/link';
+import moreIcon from '@jetbrains/icons/more-options';
+import starIcon from '@jetbrains/icons/star-empty';
+import tagIcon from '@jetbrains/icons/tag';
+import terminalIcon from '@jetbrains/icons/terminal';
+import trashIcon from '@jetbrains/icons/trash';
+import userIcon from '@jetbrains/icons/user';
+import {type ComponentProps, useState} from 'react';
+
+import Button from '../button/button';
+import DropdownMenu from '../dropdown-menu/dropdown-menu';
+import Table from '../table/table';
+import Selection from '../table/selection';
+import Tooltip from '../tooltip/tooltip';
+import SelectionToolbar, {SelectionToolbarSeparator} from './selection-toolbar';
+
+import type {Decorator} from '@storybook/react-webpack5';
+
+import styles from './selection-toolbar.stories.css';
+
+const fullScreenDecorator: Decorator = Story => (
+  <main className={styles.canvas}>
+    <Story />
+  </main>
+);
+
+export default {
+  title: 'Components/Selection Toolbar',
+  component: SelectionToolbar,
+  decorators: [fullScreenDecorator],
+  parameters: {
+    screenshots: {
+      actions: [
+        {type: 'waitForElementToShow', selector: '#storybook-root', timeout: 10_000},
+        {type: 'capture', name: '', selector: '#storybook-root'},
+      ],
+    },
+  },
+};
+
+const CloseAction = ({onClick}: {onClick?: () => void}) => (
+  <Tooltip title='Clear selection'>
+    <Button icon={closeIcon} aria-label='Clear selection' onClick={onClick} />
+  </Tooltip>
+);
+
+const Action = ({icon, label}: {icon: string; label: string}) => (
+  <Tooltip title={label}>
+    <Button icon={icon} aria-label={label} />
+  </Tooltip>
+);
+
+const Toolbar = ({
+  children,
+  onClear,
+  ...props
+}: Omit<ComponentProps<typeof SelectionToolbar>, 'closeAction'> & {onClear?: () => void}) => (
+  <div className={styles.toolbarPlacement} data-test='selection-toolbar-story'>
+    <SelectionToolbar {...props} closeAction={<CloseAction onClick={onClear} />} aria-label='Selected item actions'>
+      {children}
+    </SelectionToolbar>
+  </div>
+);
+
+const moreActions = [{label: 'Clone issue'}, {label: 'Clone issue as draft'}];
+
+const FullActions = () => (
+  <>
+    <Action icon={terminalIcon} label='Open command dialog' />
+    <Action icon={linkIcon} label='Add link' />
+    <Action icon={userIcon} label='Assign' />
+    <Action icon={tagIcon} label='Tag' />
+    <Action icon={starIcon} label='Add to favorites' />
+    <DropdownMenu anchor={<Button icon={moreIcon} aria-label='More actions' />} data={moreActions} />
+    <SelectionToolbarSeparator />
+    <Tooltip title='Delete'>
+      <Button danger icon={trashIcon} aria-label='Delete' />
+    </Tooltip>
+    <SelectionToolbarSeparator />
+  </>
+);
+
+export const PartialSelection = () => (
+  <Toolbar label='3 items selected'>
+    <FullActions />
+  </Toolbar>
+);
+
+export const CurrentPageSelected = () => (
+  <Toolbar
+    label='73 of 124 items selected'
+    selectAll={
+      <Button inline primary>
+        Select all 124 items
+      </Button>
+    }
+  >
+    <FullActions />
+  </Toolbar>
+);
+
+export const Compact = () => (
+  <Toolbar
+    compact
+    label='A very long localized selection label that has to fit into a constrained toolbar'
+    selectAll={
+      <Button inline primary>
+        Select all 124 items
+      </Button>
+    }
+    style={{width: 520}}
+  >
+    <DropdownMenu anchor={<Button icon={moreIcon} aria-label='More actions' />} data={moreActions} />
+  </Toolbar>
+);
+
+export const Rtl = () => (
+  <div dir='rtl'>
+    <Toolbar label='تم تحديد 3 عناصر'>
+      <FullActions />
+    </Toolbar>
+  </div>
+);
+
+const issues = [
+  {id: 'RG-2812', summary: 'Add Selection Toolbar', status: 'In Progress'},
+  {id: 'RG-2804', summary: 'Improve table keyboard navigation', status: 'Open'},
+  {id: 'RG-2791', summary: 'Update build configuration', status: 'Done'},
+  {id: 'RG-2788', summary: 'Align popup shadows', status: 'Open'},
+  {id: 'RG-2779', summary: 'Document selection states', status: 'In Progress'},
+];
+
+const totalIssues = 15;
+
+export const WithTable = () => {
+  const [selection, setSelection] = useState(
+    () => new Selection({data: issues, selected: new Set(issues.slice(0, 2))}),
+  );
+  const [allResultsSelected, setAllResultsSelected] = useState(false);
+  const selectedCount = selection.getSelected().size;
+  const currentPageSelected = selectedCount === issues.length;
+  let label = `${selectedCount} items selected`;
+  if (currentPageSelected) label = `${selectedCount} of ${totalIssues} items selected`;
+  if (allResultsSelected) label = `All ${totalIssues} items selected`;
+
+  return (
+    <>
+      <Table
+        data={issues}
+        columns={[
+          {id: 'id', title: 'Issue'},
+          {id: 'summary', title: 'Summary'},
+          {id: 'status', title: 'Status'},
+        ]}
+        selectable
+        selection={selection}
+        onSelect={nextSelection => {
+          setSelection(nextSelection);
+          setAllResultsSelected(false);
+        }}
+      />
+      {selectedCount > 0 && (
+        <Toolbar
+          label={label}
+          selectAll={
+            currentPageSelected && !allResultsSelected ? (
+              <Button inline primary onClick={() => setAllResultsSelected(true)}>
+                Select all {totalIssues} items
+              </Button>
+            ) : undefined
+          }
+          onClear={() => {
+            setSelection(new Selection({data: issues}));
+            setAllResultsSelected(false);
+          }}
+        >
+          <FullActions />
+        </Toolbar>
+      )}
+    </>
+  );
+};

--- a/src/selection-toolbar/selection-toolbar.test.tsx
+++ b/src/selection-toolbar/selection-toolbar.test.tsx
@@ -1,0 +1,61 @@
+import {createRef} from 'react';
+import {render, screen} from '@testing-library/react';
+
+import SelectionToolbar, {SelectionToolbarSeparator} from './selection-toolbar';
+
+describe('SelectionToolbar', () => {
+  const closeAction = <button type='button'>{'Clear selection'}</button>;
+
+  it('renders its slots and accessibility semantics', () => {
+    render(
+      <SelectionToolbar
+        label='2 items selected'
+        selectAll={<button type='button'>{'Select all'}</button>}
+        closeAction={closeAction}
+        aria-label='Selected item actions'
+      >
+        <button type='button'>{'Edit'}</button>
+        <SelectionToolbarSeparator />
+      </SelectionToolbar>,
+    );
+
+    expect(screen.getByRole('group', {name: 'Selected item actions'})).to.exist;
+    expect(screen.getByText('2 items selected')).to.exist;
+    expect(screen.getByRole('button', {name: 'Select all'})).to.exist;
+    expect(screen.getByRole('button', {name: 'Edit'})).to.exist;
+    expect(screen.getByRole('button', {name: 'Clear selection'})).to.exist;
+    expect(screen.getByRole('separator')).to.have.attribute('aria-orientation', 'vertical');
+  });
+
+  it('omits select-all content when it is not supplied', () => {
+    render(<SelectionToolbar label='All selected' closeAction={closeAction} />);
+    expect(screen.getByRole('group', {name: 'All selected'})).to.exist;
+    expect(screen.queryByRole('button', {name: 'Select all'})).to.be.null;
+  });
+
+  it('renders valid falsy select-all content', () => {
+    render(<SelectionToolbar label='Selected' selectAll={0} closeAction={closeAction} />);
+    expect(screen.getByText('0')).to.exist;
+  });
+
+  it('forwards attributes, class name, ref, data-test, and compact state', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <SelectionToolbar
+        ref={ref}
+        label='Selected'
+        closeAction={closeAction}
+        compact
+        className='custom'
+        title='Selection actions'
+        data-test='consumer-toolbar'
+      />,
+    );
+
+    expect(ref.current).to.equal(screen.getByRole('group'));
+    expect(ref.current).to.have.class('custom');
+    expect(ref.current?.className).to.contain('compact');
+    expect(ref.current).to.have.attribute('title', 'Selection actions');
+    expect(ref.current).to.have.attribute('data-test', 'ring-selection-toolbar consumer-toolbar');
+  });
+});

--- a/src/selection-toolbar/selection-toolbar.test.tsx
+++ b/src/selection-toolbar/selection-toolbar.test.tsx
@@ -3,6 +3,8 @@ import {render, screen} from '@testing-library/react';
 
 import SelectionToolbar, {SelectionToolbarSeparator} from './selection-toolbar';
 
+import styles from './selection-toolbar.css';
+
 describe('SelectionToolbar', () => {
   const closeAction = <button type='button'>{'Clear selection'}</button>;
 
@@ -54,7 +56,7 @@ describe('SelectionToolbar', () => {
 
     expect(ref.current).to.equal(screen.getByRole('group'));
     expect(ref.current).to.have.class('custom');
-    expect(ref.current?.className).to.contain('compact');
+    expect(ref.current).to.have.class(styles.compact);
     expect(ref.current).to.have.attribute('title', 'Selection actions');
     expect(ref.current).to.have.attribute('data-test', 'ring-selection-toolbar consumer-toolbar');
   });

--- a/src/selection-toolbar/selection-toolbar.tsx
+++ b/src/selection-toolbar/selection-toolbar.tsx
@@ -1,0 +1,62 @@
+import {forwardRef, type HTMLAttributes, type ReactNode, type Ref, useId} from 'react';
+import classNames from 'classnames';
+
+import dataTests from '../global/data-tests';
+import Theme, {ThemeProvider} from '../global/theme';
+
+import styles from './selection-toolbar.css';
+
+export interface SelectionToolbarProps extends HTMLAttributes<HTMLDivElement> {
+  label: ReactNode;
+  selectAll?: ReactNode;
+  closeAction: ReactNode;
+  compact?: boolean;
+  'data-test'?: string | null;
+}
+
+export const SelectionToolbar = forwardRef<HTMLDivElement, SelectionToolbarProps>(function SelectionToolbar(
+  {
+    label,
+    selectAll,
+    closeAction,
+    compact,
+    className,
+    children,
+    'data-test': dataTest,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    ...restProps
+  },
+  ref,
+) {
+  const labelId = useId();
+  const hasSelectAll = selectAll != null;
+
+  return (
+    <ThemeProvider
+      {...restProps}
+      ref={ref as Ref<HTMLElement>}
+      theme={Theme.DARK}
+      role='group'
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy ?? (ariaLabel == null ? labelId : undefined)}
+      data-test={dataTests('ring-selection-toolbar', dataTest)}
+      className={classNames(styles.toolbar, {[styles.compact]: compact}, className)}
+    >
+      <div className={styles.content}>
+        <span id={labelId} className={styles.label}>
+          {label}
+        </span>
+        {hasSelectAll && <span className={styles.selectAll}>{selectAll}</span>}
+        <div className={styles.actions}>{children}</div>
+      </div>
+      <div className={styles.closeAction}>{closeAction}</div>
+    </ThemeProvider>
+  );
+});
+
+export function SelectionToolbarSeparator() {
+  return <span role='separator' aria-orientation='vertical' className={styles.separator} />;
+}
+
+export default SelectionToolbar;

--- a/src/selection-toolbar/selection-toolbar.tsx
+++ b/src/selection-toolbar/selection-toolbar.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, type HTMLAttributes, type ReactNode, type Ref, useId} from 'react';
+import {type ComponentPropsWithRef, type ReactNode, type Ref, useId} from 'react';
 import classNames from 'classnames';
 
 import dataTests from '../global/data-tests';
@@ -6,7 +6,7 @@ import Theme, {ThemeProvider} from '../global/theme';
 
 import styles from './selection-toolbar.css';
 
-export interface SelectionToolbarProps extends HTMLAttributes<HTMLDivElement> {
+export interface SelectionToolbarProps extends ComponentPropsWithRef<'div'> {
   label: ReactNode;
   selectAll?: ReactNode;
   closeAction: ReactNode;
@@ -14,21 +14,19 @@ export interface SelectionToolbarProps extends HTMLAttributes<HTMLDivElement> {
   'data-test'?: string | null;
 }
 
-export const SelectionToolbar = forwardRef<HTMLDivElement, SelectionToolbarProps>(function SelectionToolbar(
-  {
-    label,
-    selectAll,
-    closeAction,
-    compact,
-    className,
-    children,
-    'data-test': dataTest,
-    'aria-label': ariaLabel,
-    'aria-labelledby': ariaLabelledBy,
-    ...restProps
-  },
+export function SelectionToolbar({
   ref,
-) {
+  label,
+  selectAll,
+  closeAction,
+  compact,
+  className,
+  children,
+  'data-test': dataTest,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  ...restProps
+}: SelectionToolbarProps) {
   const labelId = useId();
   const hasSelectAll = selectAll != null;
 
@@ -53,7 +51,7 @@ export const SelectionToolbar = forwardRef<HTMLDivElement, SelectionToolbarProps
       <div className={styles.closeAction}>{closeAction}</div>
     </ThemeProvider>
   );
-});
+}
 
 export function SelectionToolbarSeparator() {
   return <span role='separator' aria-orientation='vertical' className={styles.separator} />;


### PR DESCRIPTION
## Motivation

Selection controls currently require products to recreate the same floating toolbar presentation. This adds a reusable Ring UI component with composable label, select-all, actions, separators, and clear-selection slots, including compact and RTL layouts.

## Links

- [RG-2812](https://youtrack.jetbrains.com/issue/RG-2812)
- [Figma](https://www.figma.com/design/HY6d4uE1xxaQXCMG9fe6Y2/RingUI?node-id=21067-660&m=dev)

## Demo

![Selection Toolbar with Table](https://github.com/JetBrains/ring-ui/blob/3fbbdc4624f03cf2ab9d354ca1ed63eee17d924d/packages/screenshots/testplane/chrome/components/selection%20toolbar/with%20table/with%20table.png?raw=true)