### PR TITLE
TW-103733 Improve CollapsibleGroup interaction UX

### DIFF
--- a/packages/screenshots/testplane/chrome/components/collapsiblegroup/collapsed by default/collapsed by default-dark.png
+++ b/packages/screenshots/testplane/chrome/components/collapsiblegroup/collapsed by default/collapsed by default-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c68e6aaded326212fa28622f9de8819a7bde66b414182ad21c22feab27eab05
-size 3344
+oid sha256:1f994d7808b989f691043c1bbaae69833d3bf85c0c2d7834f99032d0fe272760
+size 4153

--- a/packages/screenshots/testplane/chrome/components/collapsiblegroup/collapsed by default/collapsed by default-keyboard focus.png
+++ b/packages/screenshots/testplane/chrome/components/collapsiblegroup/collapsed by default/collapsed by default-keyboard focus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a40a69ce291e2e0ea78ddb2c42526653ce07fa24901712f36f1af075d236aeb0
+size 4050

--- a/packages/screenshots/testplane/firefox/components/collapsiblegroup/collapsed by default/collapsed by default-dark.png
+++ b/packages/screenshots/testplane/firefox/components/collapsiblegroup/collapsed by default/collapsed by default-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e439d0af8cc7858d813e20d8b9a7af6a3a78f60bbfbb8434e87b31c4e4e2efa8
-size 4734
+oid sha256:7bf45ddd6d94f893b6b8c4b64dab4dab6ccda74dab0e6166d175c27c118cb7cf
+size 5527

--- a/packages/screenshots/testplane/firefox/components/collapsiblegroup/collapsed by default/collapsed by default-keyboard focus.png
+++ b/packages/screenshots/testplane/firefox/components/collapsiblegroup/collapsed by default/collapsed by default-keyboard focus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98209574fff5637759cb4d488c825b214f6552fad337862f9f6221ce129ddf80
+size 5322

--- a/src/collapse/collapse-content.tsx
+++ b/src/collapse/collapse-content.tsx
@@ -10,7 +10,6 @@ import {COLLAPSE_CONTENT_TEST_ID, COLLAPSE_CONTENT_CONTAINER_TEST_ID} from './co
 
 import styles from './collapse.css';
 
-const DURATION_FACTOR = 0.5;
 const DEFAULT_HEIGHT = 0;
 const VISIBLE = 1;
 const HIDDEN = 0;
@@ -42,7 +41,7 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
   minHeight = DEFAULT_HEIGHT,
   'data-test': dataTest,
 }) => {
-  const {collapsed, duration, id, disableAnimation, keepMounted} = use(CollapseContext);
+  const {collapsed, duration, id, animate, disableAnimation, keepMounted} = use(CollapseContext);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [initialContentHeight] = useState<number>(minHeight);
@@ -106,9 +105,8 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
     }
   }, []);
 
-  const calculatedDuration = duration + contentHeight * DURATION_FACTOR;
   const style = {
-    '--duration': `${calculatedDuration}ms`,
+    '--duration': `${duration}ms`,
     height,
     opacity: collapsed && !minHeight ? HIDDEN : VISIBLE,
   };
@@ -128,7 +126,7 @@ export const CollapseContent: React.FC<PropsWithChildren<Props>> = ({
       ref={containerRef}
       id={`collapse-content-${id}`}
       data-test={dataTests(COLLAPSE_CONTENT_CONTAINER_TEST_ID)}
-      className={classNames(styles.container, {[styles.transition]: !disableAnimation})}
+      className={classNames(styles.container, {[styles.transition]: animate && !disableAnimation})}
       style={style}
     >
       <div

--- a/src/collapse/collapse-context.ts
+++ b/src/collapse/collapse-context.ts
@@ -5,6 +5,7 @@ import {BASE_ANIMATION_DURATION} from './consts';
 interface CollapseContextInterface {
   collapsed: boolean;
   duration: number;
+  animate: boolean;
   disableAnimation: boolean;
   keepMounted?: boolean;
   setCollapsed: () => void;
@@ -14,6 +15,7 @@ interface CollapseContextInterface {
 export const CollapseContext = createContext<CollapseContextInterface>({
   collapsed: true,
   duration: BASE_ANIMATION_DURATION,
+  animate: false,
   disableAnimation: false,
   keepMounted: false,
   setCollapsed: () => {},

--- a/src/collapse/collapse.css
+++ b/src/collapse/collapse.css
@@ -7,8 +7,14 @@
 
 .transition {
   transition:
-    height var(--duration) ease-in-out 0s,
-    opacity var(--duration) ease-in-out 0s;
+    height var(--duration) cubic-bezier(0.2, 0, 0, 1) 0s,
+    opacity var(--duration) cubic-bezier(0.2, 0, 0, 1) 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .transition {
+    transition: none;
+  }
 }
 
 .summary {

--- a/src/collapse/collapse.test.tsx
+++ b/src/collapse/collapse.test.tsx
@@ -158,6 +158,27 @@ describe('<Collapse />', () => {
     expect(content.className).to.not.include(styles.transition);
   });
 
+  it('should animate state changes but not initial expanded renders', () => {
+    const {unmount} = renderComponent(0, false, false, false);
+
+    expect(screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID).className).to.not.include(styles.transition);
+
+    unmount();
+
+    const controlled = (collapsed: boolean) => (
+      <Collapse collapsed={collapsed}>
+        <CollapseContent>{textMock}</CollapseContent>
+      </Collapse>
+    );
+    const {rerender} = render(controlled(false));
+    const controlledContent = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
+
+    expect(controlledContent.className).to.not.include(styles.transition);
+
+    rerender(controlled(true));
+    expect(controlledContent.className).to.include(styles.transition);
+  });
+
   it('should use control as render prop', () => {
     renderComponent(0, true);
 
@@ -302,7 +323,7 @@ describe('<Collapse />', () => {
     }
   });
 
-  it('should not hide kept-mounted content before the running transition can finish', () => {
+  it('should use the fixed collapse duration for any content height', () => {
     vi.useFakeTimers();
     let resize: (() => void) | undefined;
     vi.stubGlobal(
@@ -331,22 +352,47 @@ describe('<Collapse />', () => {
       );
 
       const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+      const container = screen.getByTestId(COLLAPSE_CONTENT_CONTAINER_TEST_ID);
 
-      // grow the content so the collapse transition gets a long duration (200 + 1000 * 0.5 = 700ms)
       getRectMock.mockReturnValue({top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 1000});
       act(() => resize?.());
 
-      // the content shrinks in the same update that collapses the panel:
-      // the fallback must follow the committed --duration, not the fresh DOM height
-      getRectMock.mockReturnValue({top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0});
       fireEvent.click(screen.getByRole('button', {name: 'Toggle'}));
 
-      act(() => vi.advanceTimersByTime(400));
+      expect(container.style.getPropertyValue('--duration')).to.equal('200ms');
+
+      act(() => vi.advanceTimersByTime(299));
       expect(content.style.visibility).to.equal('');
 
-      act(() => vi.advanceTimersByTime(500));
+      act(() => vi.advanceTimersByTime(1));
       expect(content.style.visibility).to.equal('hidden');
       expect(content.hasAttribute('inert')).to.equal(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should not hide kept-mounted content before the running transition can finish', () => {
+    vi.useFakeTimers();
+
+    try {
+      render(
+        <Collapse keepMounted duration={1000} defaultCollapsed={false}>
+          <CollapseControl>
+            <button type='button'>{'Toggle'}</button>
+          </CollapseControl>
+          <CollapseContent>{textMock}</CollapseContent>
+        </Collapse>,
+      );
+
+      const content = screen.getByTestId(COLLAPSE_CONTENT_TEST_ID);
+      fireEvent.click(screen.getByRole('button', {name: 'Toggle'}));
+
+      act(() => vi.advanceTimersByTime(1099));
+      expect(content.style.visibility).to.equal('');
+
+      act(() => vi.advanceTimersByTime(1));
+      expect(content.style.visibility).to.equal('hidden');
     } finally {
       vi.useRealTimers();
     }

--- a/src/collapse/collapse.tsx
+++ b/src/collapse/collapse.tsx
@@ -40,8 +40,16 @@ export const Collapse: React.FC<PropsWithChildren<Props>> = ({
   const id = useId();
 
   const finalCollapsedValue = collapsed ?? innerCollapsed;
+  const [previousCollapsedValue, setPreviousCollapsedValue] = useState(finalCollapsedValue);
+  const [animate, setAnimate] = useState(false);
+
+  if (previousCollapsedValue !== finalCollapsedValue) {
+    setPreviousCollapsedValue(finalCollapsedValue);
+    setAnimate(true);
+  }
 
   const setCollapsed = () => {
+    setAnimate(true);
     setInnerCollapsed(!finalCollapsedValue);
     onChange(!finalCollapsedValue);
   };
@@ -53,6 +61,7 @@ export const Collapse: React.FC<PropsWithChildren<Props>> = ({
           collapsed: finalCollapsedValue,
           setCollapsed,
           duration,
+          animate,
           disableAnimation,
           keepMounted,
           id,

--- a/src/collapsible-group/collapsible-group.css
+++ b/src/collapsible-group/collapsible-group.css
@@ -25,7 +25,7 @@
   box-shadow: var(--ring-popup-shadow);
 }
 
-.focused {
+.expand:has(.headerButton:focus-visible) {
   box-shadow: 0 0 0 2px var(--ring-border-hover-color), var(--ring-popup-shadow);
 }
 

--- a/src/collapsible-group/collapsible-group.stories.tsx
+++ b/src/collapsible-group/collapsible-group.stories.tsx
@@ -91,7 +91,11 @@ CollapsedByDefault.storyName = 'Collapsed by default';
 CollapsedByDefault.parameters = {
   screenshots: {
     captureSelector,
-    actions: [{type: 'capture', name: '', selector: captureSelector}],
+    actions: [
+      {type: 'capture', name: '', selector: captureSelector},
+      {type: 'focus', selector: `${captureSelector} button`},
+      {type: 'capture', name: 'keyboard focus', selector: captureSelector},
+    ],
   },
 };
 

--- a/src/collapsible-group/collapsible-group.test.tsx
+++ b/src/collapsible-group/collapsible-group.test.tsx
@@ -86,9 +86,7 @@ describe('<CollapsibleGroup />', () => {
     expect(onChangeCalls).toHaveLength(0);
   });
 
-  it('should keep hover and focus styles scoped to the interactive header', async () => {
-    const user = userEvent.setup();
-
+  it('should keep hover styles scoped to the interactive header', async () => {
     render(
       <CollapsibleGroup title={'Title'} defaultExpanded data-test='expand'>
         <button type='button'>{'Action'}</button>
@@ -97,23 +95,13 @@ describe('<CollapsibleGroup />', () => {
 
     const root = document.querySelector('[data-test="expand"]') as HTMLDivElement;
     const header = screen.getByRole('button', {name: 'Title'});
-    const bodyButton = screen.getByRole('button', {name: 'Action'});
-
     expect(root.className).not.toContain(styles.hovered);
-    expect(root.className).not.toContain(styles.focused);
 
     await userEvent.hover(header);
     expect(root.className).toContain(styles.hovered);
 
     await userEvent.unhover(header);
     expect(root.className).not.toContain(styles.hovered);
-
-    await user.tab();
-    expect(root.className).toContain(styles.focused);
-
-    await user.tab();
-    expect(document.activeElement).toBe(bodyButton);
-    expect(root.className).not.toContain(styles.focused);
   });
 
   it('should preserve child state across a collapse cycle when keepMounted is set', async () => {

--- a/src/collapsible-group/collapsible-group.tsx
+++ b/src/collapsible-group/collapsible-group.tsx
@@ -114,7 +114,6 @@ const CollapsibleGroup = ({
 }: CollapsibleGroupProps) => {
   const [innerExpanded, setInnerExpanded] = useState(defaultExpanded);
   const [hovered, setHovered] = useState(false);
-  const [focused, setFocused] = useState(false);
   const isExpanded = expanded ?? innerExpanded;
 
   const handleChange = (collapsed: boolean) => {
@@ -125,18 +124,9 @@ const CollapsibleGroup = ({
     onChange(nextExpanded);
   };
 
-  const onBlur = (event: React.FocusEvent<HTMLElement>) => {
-    const nextTarget = event.relatedTarget;
-    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
-      return;
-    }
-    setFocused(false);
-  };
-
   const classes = classNames(styles.expand, className, {
     [styles.hovered]: hovered,
     [styles.expanded]: isExpanded,
-    [styles.focused]: focused,
   });
 
   const header = interactive ? (
@@ -146,8 +136,6 @@ const CollapsibleGroup = ({
       subtitle={subtitle}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      onFocus={() => setFocused(true)}
-      onBlur={onBlur}
     />
   ) : (
     <CollapsibleGroupHeaderStatic avatar={avatar} titleContent={title} subtitle={subtitle} />


### PR DESCRIPTION
This addresses some items from [TW-103733](https://youtrack.jetbrains.com/issue/TW-103733) [DESIGN REVIEW] Build Overview Tab UX improvements

- show the CollapsibleGroup highlight only for keyboard focus
- use a fixed 200ms collapse transition with the updated easing and reduced-motion support
- skip expansion animation on initial render

